### PR TITLE
Expose overlay and extract package.nix from flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,28 @@ The resulting app will be located at:
 
     build/Luma.app
 
+## Nix
+
+Luma provides a [Nix](https://nixos.org) flake for running and
+installing on Linux:
+
+```sh
+nix run github:frida/luma        # run Luma without installing
+nix shell github:frida/luma      # shell with luma in PATH
+nix build github:frida/luma      # build into the Nix store
+```
+
+The flake exposes an overlay so you can add Luma to your own Nix
+configuration:
+
+```nix
+inputs.luma.url = "github:frida/luma";
+nixpkgs.overlays = [ luma.overlays.default ];
+```
+
+After applying the overlay, `pkgs.luma` is available in your
+package set.
+
 ## Building the GTK frontend (Linux)
 
 ### Prerequisites (Fedora)

--- a/flake.nix
+++ b/flake.nix
@@ -7,62 +7,17 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    {
+      overlays.default = final: _: {
+        luma = final.callPackage ./package.nix { };
+      };
+    } // flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
+        luma = pkgs.callPackage ./package.nix { };
       in
       {
         packages.default = self.packages.${system}.luma;
-
-        packages.luma = pkgs.stdenv.mkDerivation rec {
-          pname = "luma";
-          version = "1.0.4";
-
-          src = pkgs.fetchurl {
-            url = "https://github.com/frida/luma/releases/download/${version}/luma-${version}-ubuntu-24.04-x86_64.deb";
-            hash = "sha256-zz2T0kGrJaCp3eC75onyjJRrYg/6gWhH/ZHln1G80KA=";
-          };
-
-          nativeBuildInputs = with pkgs; [
-            dpkg
-            autoPatchelfHook
-            wrapGAppsHook4
-          ];
-
-          buildInputs = with pkgs; [
-            libadwaita
-            webkitgtk_6_0
-            libzip
-            libnice
-            swift
-            adwaita-icon-theme
-            hicolor-icon-theme
-            libgee
-            libxml2
-            atk
-            sqlite
-            glib-networking
-          ];
-
-          unpackPhase = "dpkg-deb -x $src .";
-
-          installPhase = ''
-            runHook preInstall
-            mkdir -p $out
-            cp -r usr/. $out/
-            patchelf --replace-needed libzip.so.4 libzip.so $out/bin/luma
-            patchelf --replace-needed libxml2.so.2 libxml2.so \
-              $out/lib/luma/swift/libFoundationXML.so
-            runHook postInstall
-          '';
-
-          meta = with pkgs.lib; {
-            description = "The official Frida GUI";
-            homepage = "https://luma.frida.re/";
-            license = licenses.mit;
-            platforms = [ "x86_64-linux" ];
-            mainProgram = "luma";
-          };
-        };
+        packages.luma = luma;
       });
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,70 @@
+{
+  lib,
+  stdenv,
+  fetchurl,
+  dpkg,
+  autoPatchelfHook,
+  wrapGAppsHook4,
+  libadwaita,
+  webkitgtk_6_0,
+  libzip,
+  libnice,
+  swift,
+  adwaita-icon-theme,
+  hicolor-icon-theme,
+  libgee,
+  libxml2,
+  atk,
+  sqlite,
+  glib-networking,
+}:
+stdenv.mkDerivation (finalAttrs: {
+  pname = "luma";
+  version = "1.0.4";
+
+  src = fetchurl {
+    url = "https://github.com/frida/luma/releases/download/${finalAttrs.version}/luma-${finalAttrs.version}-ubuntu-24.04-x86_64.deb";
+    hash = "sha256-zz2T0kGrJaCp3eC75onyjJRrYg/6gWhH/ZHln1G80KA=";
+  };
+
+  nativeBuildInputs = [
+    dpkg
+    autoPatchelfHook
+    wrapGAppsHook4
+  ];
+
+  buildInputs = [
+    libadwaita
+    webkitgtk_6_0
+    libzip
+    libnice
+    swift
+    adwaita-icon-theme
+    hicolor-icon-theme
+    libgee
+    libxml2
+    atk
+    sqlite
+    glib-networking
+  ];
+
+  unpackPhase = "dpkg-deb -x $src .";
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out
+    cp -r usr/. $out/
+    patchelf --replace-needed libzip.so.4 libzip.so $out/bin/luma
+    patchelf --replace-needed libxml2.so.2 libxml2.so \
+      $out/lib/luma/swift/libFoundationXML.so
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "The official Frida GUI";
+    homepage = "https://luma.frida.re/";
+    license = lib.licenses.mit;
+    platforms = [ "x86_64-linux" ];
+    mainProgram = "luma";
+  };
+})


### PR DESCRIPTION
Extract the Luma derivation into `package.nix` and expose
`overlays.default` at the flake root so Nix users can install
Luma via their own configuration:

```nix
inputs.luma.url = "github:frida/luma";
nixpkgs.overlays = [ luma.overlays.default ];
# → pkgs.luma
```
nix run, nix shell, and nix build continue to work via
packages.default / packages.luma.