### PR TITLE
[Fix] Harden Luma bug paths

### DIFF
--- a/Agent/core/itrace.ts
+++ b/Agent/core/itrace.ts
@@ -97,7 +97,9 @@ export class Trace {
 
         let drain: DrainMode = "in-agent";
         recv("itrace:ack:" + token, message => {
-            drain = message.drain;
+            if (message.drain === "system" || message.drain === "in-agent") {
+                drain = message.drain;
+            }
         }).wait();
         return drain;
     }

--- a/Luma/CustomInstrumentEditorView.swift
+++ b/Luma/CustomInstrumentEditorView.swift
@@ -15,6 +15,7 @@ struct CustomInstrumentEditorView: View {
     @State private var activePath: String?
     @State private var pendingPath: String?
     @State private var showUnsavedAlert = false
+    @State private var errorMessage: String?
 
     private var def: CustomInstrumentDef? {
         engine.customInstruments.def(withId: defID)
@@ -55,6 +56,11 @@ struct CustomInstrumentEditorView: View {
             if displayedFile == nil {
                 applyNavigation(toPath: newEntrypoint)
             }
+        }
+        .alert("Custom instrument error", isPresented: errorBinding, presenting: errorMessage) { _ in
+            Button("OK") { errorMessage = nil }
+        } message: { message in
+            Text(message)
         }
     }
 
@@ -169,11 +175,15 @@ struct CustomInstrumentEditorView: View {
         let pathToSave = file.path
         let content = draftContent
         Task { @MainActor in
-            engine.writeCustomInstrumentFile(defID: defID, path: pathToSave, content: content)
-            isDirty = false
-            showSavedCheck = true
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            withAnimation { showSavedCheck = false }
+            do {
+                _ = try engine.writeCustomInstrumentFile(defID: defID, path: pathToSave, content: content)
+                isDirty = false
+                showSavedCheck = true
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                withAnimation { showSavedCheck = false }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
@@ -182,8 +192,19 @@ struct CustomInstrumentEditorView: View {
         let pathToSave = file.path
         let content = draftContent
         Task { @MainActor in
-            engine.writeCustomInstrumentFile(defID: defID, path: pathToSave, content: content)
+            do {
+                _ = try engine.writeCustomInstrumentFile(defID: defID, path: pathToSave, content: content)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
         }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
     }
 
     private func syncFromFile(_ file: CustomInstrumentFile) {

--- a/Luma/CustomInstrumentMetadataMenu.swift
+++ b/Luma/CustomInstrumentMetadataMenu.swift
@@ -12,6 +12,7 @@ struct CustomInstrumentMetadataMenu: View {
     @State private var isShowingWidgetsEditor = false
     @State private var isShowingDeleteConfirm = false
     @State private var renameEntrypointPrompt = RenamePromptState()
+    @State private var errorMessage: String?
 
     private var def: CustomInstrumentDef? {
         engine.customInstruments.def(withId: defID)
@@ -100,6 +101,11 @@ struct CustomInstrumentMetadataMenu: View {
         } message: {
             Text("This removes the custom instrument from the project and from any sessions where it is loaded.")
         }
+        .alert("Custom instrument error", isPresented: errorBinding, presenting: errorMessage) { _ in
+            Button("OK") { errorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
     }
 
     private func commitRenameEntrypoint() {
@@ -107,10 +113,13 @@ struct CustomInstrumentMetadataMenu: View {
         guard !trimmed.isEmpty, let original = def?.entrypoint, trimmed != original else { return }
         let id = defID
         Task { @MainActor in
-            engine.renameCustomInstrumentFile(defID: id, from: original, to: trimmed)
-            engine.setCustomInstrumentEntrypoint(defID: id, path: trimmed)
-            if selection == .customInstrumentFile(id, original) {
-                selection = .customInstrumentFile(id, trimmed)
+            do {
+                let renamedPath = try engine.renameCustomInstrumentFile(defID: id, from: original, to: trimmed)
+                if selection == .customInstrumentFile(id, original) {
+                    selection = .customInstrumentFile(id, renamedPath)
+                }
+            } catch {
+                errorMessage = error.localizedDescription
             }
         }
     }
@@ -123,5 +132,12 @@ struct CustomInstrumentMetadataMenu: View {
                 selection = .notebook
             }
         }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
     }
 }

--- a/Luma/ITraceCFGView.swift
+++ b/Luma/ITraceCFGView.swift
@@ -33,13 +33,19 @@ struct ITraceCFGView: NSViewRepresentable {
         let container = CFGContainerView()
 
         let metalView = container.metalView
-        metalView.device = MTLCreateSystemDefaultDevice()
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            context.coordinator.container = container
+            container.coordinator = context.coordinator
+            return container
+        }
+
+        metalView.device = device
         metalView.delegate = context.coordinator
         metalView.enableSetNeedsDisplay = true
         metalView.isPaused = true
         metalView.clearColor = MTLClearColor(red: 0.1, green: 0.1, blue: 0.12, alpha: 1)  // Updated in updateNSView
 
-        context.coordinator.setup(device: metalView.device!, view: metalView)
+        context.coordinator.setup(device: device, view: metalView)
         context.coordinator.container = container
 
         let click = NSClickGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleClick(_:)))
@@ -420,9 +426,9 @@ extension ITraceCFGView {
         private var nodeHeightCache: [UInt64: CGFloat] = [:]
         private var fetchTask: Task<Void, Never>?
 
-        private var device: MTLDevice!
-        private var commandQueue: MTLCommandQueue!
-        private var pipelineState: MTLRenderPipelineState!
+        private var device: MTLDevice?
+        private var commandQueue: MTLCommandQueue?
+        private var pipelineState: MTLRenderPipelineState?
 
         var camera = Camera()
 
@@ -446,19 +452,22 @@ extension ITraceCFGView {
 
         func setup(device: MTLDevice, view: MTKView) {
             self.device = device
-            self.commandQueue = device.makeCommandQueue()
-
-            let library = try! device.makeDefaultLibrary(bundle: Bundle.main)
+            guard let commandQueue = device.makeCommandQueue(),
+                let library = try? device.makeDefaultLibrary(bundle: Bundle.main),
+                let vertex = library.makeFunction(name: "cfgVertexShader"),
+                let fragment = library.makeFunction(name: "cfgFragmentShader")
+            else { return }
+            self.commandQueue = commandQueue
 
             let desc = MTLRenderPipelineDescriptor()
-            desc.vertexFunction = library.makeFunction(name: "cfgVertexShader")
-            desc.fragmentFunction = library.makeFunction(name: "cfgFragmentShader")
+            desc.vertexFunction = vertex
+            desc.fragmentFunction = fragment
             desc.colorAttachments[0].pixelFormat = view.colorPixelFormat
             desc.colorAttachments[0].isBlendingEnabled = true
             desc.colorAttachments[0].sourceRGBBlendFactor = .sourceAlpha
             desc.colorAttachments[0].destinationRGBBlendFactor = .oneMinusSourceAlpha
 
-            pipelineState = try! device.makeRenderPipelineState(descriptor: desc)
+            pipelineState = try? device.makeRenderPipelineState(descriptor: desc)
         }
 
         private let titleHeight: CGFloat = 16
@@ -541,7 +550,10 @@ extension ITraceCFGView {
         func mtkView(_ view: MTKView, drawableSizeWillChange size: CGSize) {}
 
         func draw(in view: MTKView) {
-            guard let drawable = view.currentDrawable,
+            guard let device,
+                let commandQueue,
+                let pipelineState,
+                let drawable = view.currentDrawable,
                 let descriptor = view.currentRenderPassDescriptor
             else { return }
 
@@ -702,14 +714,15 @@ extension ITraceCFGView {
 
             guard !vertices.isEmpty else { return }
 
-            let buffer = device.makeBuffer(
+            guard let buffer = device.makeBuffer(
                 bytes: vertices,
                 length: vertices.count * MemoryLayout<Vertex>.stride,
                 options: .storageModeShared
-            )
+            ) else { return }
 
-            let commandBuffer = commandQueue.makeCommandBuffer()!
-            let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor)!
+            guard let commandBuffer = commandQueue.makeCommandBuffer(),
+                let encoder = commandBuffer.makeRenderCommandEncoder(descriptor: descriptor)
+            else { return }
             encoder.setRenderPipelineState(pipelineState)
             encoder.setVertexBuffer(buffer, offset: 0, index: 0)
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: vertices.count)
@@ -1400,4 +1413,3 @@ struct ITraceCFGView: View {
 }
 
 #endif
-

--- a/Luma/Instruments/CustomInstrumentSidebar.swift
+++ b/Luma/Instruments/CustomInstrumentSidebar.swift
@@ -199,7 +199,7 @@ struct SidebarCustomInstrumentDefRow: View {
             }
             exportBundle = nil
         }
-        .alert("Export failed", isPresented: exportErrorBinding, presenting: exportErrorMessage) { _ in
+        .alert("Custom instrument error", isPresented: exportErrorBinding, presenting: exportErrorMessage) { _ in
             Button("OK") { exportErrorMessage = nil }
         } message: { message in
             Text(message)
@@ -252,8 +252,12 @@ struct SidebarCustomInstrumentDefRow: View {
         guard !trimmed.isEmpty else { return }
         let defID = def.id
         Task { @MainActor in
-            engine.writeCustomInstrumentFile(defID: defID, path: trimmed, content: "")
-            selection = .customInstrumentFile(defID, trimmed)
+            do {
+                let path = try engine.writeCustomInstrumentFile(defID: defID, path: trimmed, content: "")
+                selection = .customInstrumentFile(defID, path)
+            } catch {
+                exportErrorMessage = error.localizedDescription
+            }
         }
         addFilePrompt.reset()
     }
@@ -264,9 +268,13 @@ struct SidebarCustomInstrumentDefRow: View {
         guard !to.isEmpty, to != from else { return }
         let defID = def.id
         Task { @MainActor in
-            engine.renameCustomInstrumentFile(defID: defID, from: from, to: to)
-            if selection == .customInstrumentFile(defID, from) {
-                selection = .customInstrumentFile(defID, to)
+            do {
+                let renamedPath = try engine.renameCustomInstrumentFile(defID: defID, from: from, to: to)
+                if selection == .customInstrumentFile(defID, from) {
+                    selection = .customInstrumentFile(defID, renamedPath)
+                }
+            } catch {
+                exportErrorMessage = error.localizedDescription
             }
         }
         renameEntrypointPrompt.reset()
@@ -312,6 +320,7 @@ struct SidebarCustomInstrumentFileRow: View {
 
     @State private var renamePrompt = RenamePromptState()
     @State private var isShowingDeleteConfirm = false
+    @State private var errorMessage: String?
 
     private var isEntrypoint: Bool { file.path == def.entrypoint }
     private var canDelete: Bool { !isEntrypoint }
@@ -370,13 +379,22 @@ struct SidebarCustomInstrumentFileRow: View {
         } message: {
             Text("Removes this file from the instrument.")
         }
+        .alert("Custom instrument error", isPresented: errorBinding, presenting: errorMessage) { _ in
+            Button("OK") { errorMessage = nil }
+        } message: { message in
+            Text(message)
+        }
     }
 
     private func setAsEntrypoint() {
         let defID = def.id
         let path = file.path
         Task { @MainActor in
-            engine.setCustomInstrumentEntrypoint(defID: defID, path: path)
+            do {
+                _ = try engine.setCustomInstrumentEntrypoint(defID: defID, path: path)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
         }
     }
 
@@ -386,9 +404,13 @@ struct SidebarCustomInstrumentFileRow: View {
         guard !to.isEmpty, to != from else { return }
         let defID = def.id
         Task { @MainActor in
-            engine.renameCustomInstrumentFile(defID: defID, from: from, to: to)
-            if selection == .customInstrumentFile(defID, from) {
-                selection = .customInstrumentFile(defID, to)
+            do {
+                let renamedPath = try engine.renameCustomInstrumentFile(defID: defID, from: from, to: to)
+                if selection == .customInstrumentFile(defID, from) {
+                    selection = .customInstrumentFile(defID, renamedPath)
+                }
+            } catch {
+                errorMessage = error.localizedDescription
             }
         }
         renamePrompt.reset()
@@ -399,11 +421,22 @@ struct SidebarCustomInstrumentFileRow: View {
         let path = file.path
         let entrypoint = def.entrypoint
         Task { @MainActor in
-            engine.deleteCustomInstrumentFile(defID: defID, path: path)
-            if selection == .customInstrumentFile(defID, path) {
-                selection = .customInstrumentFile(defID, entrypoint)
+            do {
+                try engine.deleteCustomInstrumentFile(defID: defID, path: path)
+                if selection == .customInstrumentFile(defID, path) {
+                    selection = .customInstrumentFile(defID, entrypoint)
+                }
+            } catch {
+                errorMessage = error.localizedDescription
             }
         }
+    }
+
+    private var errorBinding: Binding<Bool> {
+        Binding(
+            get: { errorMessage != nil },
+            set: { if !$0 { errorMessage = nil } }
+        )
     }
 }
 

--- a/Luma/Mission/MissionTranscriptView.swift
+++ b/Luma/Mission/MissionTranscriptView.swift
@@ -5,13 +5,27 @@ struct MissionTranscriptView: View {
     let turns: [MissionTurn]
     let actions: [MissionAction]
     let liveText: String
+    private let actionsByTurnID: [UUID: [MissionAction]]
+
+    init(turns: [MissionTurn], actions: [MissionAction], liveText: String) {
+        self.turns = turns
+        self.actions = actions
+        self.liveText = liveText
+        actionsByTurnID = Dictionary(grouping: actions.compactMap { action -> (UUID, MissionAction)? in
+            guard let turnID = action.turnID else { return nil }
+            return (turnID, action)
+        }, by: \.0).mapValues { pairs in
+            pairs.map(\.1)
+        }
+    }
 
     var body: some View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 12) {
                     ForEach(turns) { turn in
-                        TurnCard(turn: turn, actions: actionsForTurn(turn.id))
+                        TurnCard(turn: turn, actions: actionsByTurnID[turn.id] ?? [])
+                            .equatable()
                             .id(turn.id)
                     }
                     if !liveText.isEmpty {
@@ -25,19 +39,24 @@ struct MissionTranscriptView: View {
                 if let last { withAnimation { proxy.scrollTo(last, anchor: .bottom) } }
             }
             .onChange(of: liveText) { _, _ in
-                if !liveText.isEmpty { withAnimation { proxy.scrollTo("live", anchor: .bottom) } }
+                if !liveText.isEmpty { proxy.scrollTo("live", anchor: .bottom) }
             }
         }
     }
-
-    private func actionsForTurn(_ turnID: UUID) -> [MissionAction] {
-        actions.filter { $0.turnID == turnID }
-    }
 }
 
-private struct TurnCard: View {
+private struct TurnCard: View, Equatable {
     let turn: MissionTurn
     let actions: [MissionAction]
+    private let parsedBlocks: [LLMContentBlock]
+    private let actionKeys: [ActionRenderKey]
+
+    init(turn: MissionTurn, actions: [MissionAction]) {
+        self.turn = turn
+        self.actions = actions
+        parsedBlocks = Self.decodeBlocks(from: turn)
+        actionKeys = actions.map(ActionRenderKey.init)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -56,6 +75,14 @@ private struct TurnCard: View {
         }
         .padding()
         .background(roleColor.opacity(0.06), in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    static func == (lhs: TurnCard, rhs: TurnCard) -> Bool {
+        lhs.turn.id == rhs.turn.id
+            && lhs.turn.role == rhs.turn.role
+            && lhs.turn.contentJSON == rhs.turn.contentJSON
+            && lhs.turn.outputTokens == rhs.turn.outputTokens
+            && lhs.actionKeys == rhs.actionKeys
     }
 
     private var roleLabel: String {
@@ -89,11 +116,27 @@ private struct TurnCard: View {
         return true
     }
 
-    private var parsedBlocks: [LLMContentBlock] {
+    private static func decodeBlocks(from turn: MissionTurn) -> [LLMContentBlock] {
         guard let data = turn.contentJSON.data(using: .utf8) else { return [] }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
         return (try? decoder.decode([LLMContentBlock].self, from: data)) ?? []
+    }
+}
+
+private struct ActionRenderKey: Equatable {
+    let id: UUID
+    let status: MissionActionStatus
+    let isObserve: Bool
+    let resultSummary: String?
+    let toolCallID: String?
+
+    init(_ action: MissionAction) {
+        id = action.id
+        status = action.status
+        isObserve = action.isObserve
+        resultSummary = action.resultSummary
+        toolCallID = action.toolCallID
     }
 }
 
@@ -124,6 +167,15 @@ private struct ToolUseBlock: View {
     let name: String
     let inputJSON: String
     let action: MissionAction?
+    private let prettyInputJSON: String
+
+    init(id: String, name: String, inputJSON: String, action: MissionAction?) {
+        self.id = id
+        self.name = name
+        self.inputJSON = inputJSON
+        self.action = action
+        prettyInputJSON = prettyJSON(inputJSON)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
@@ -135,7 +187,7 @@ private struct ToolUseBlock: View {
                 Spacer()
             }
             if !inputJSON.isEmpty, inputJSON != "{}" {
-                Text(prettyJSON(inputJSON))
+                Text(prettyInputJSON)
                     .font(.caption.monospaced())
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -167,6 +219,12 @@ private struct ToolResultBlock: View {
 
 private struct TurnLiveCard: View {
     let text: String
+    private let stableText: String
+
+    init(text: String) {
+        self.text = text
+        stableText = MarkdownStreaming.stablePrefix(of: text)
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
@@ -175,7 +233,7 @@ private struct TurnLiveCard: View {
                 Text("Streaming…").font(.caption.weight(.semibold)).foregroundStyle(.blue)
                 Spacer()
             }
-            MarkdownView(MarkdownStreaming.stablePrefix(of: text))
+            MarkdownView(stableText)
         }
         .padding()
         .background(Color.blue.opacity(0.06), in: RoundedRectangle(cornerRadius: 8, style: .continuous))

--- a/Luma/Mission/MissionView.swift
+++ b/Luma/Mission/MissionView.swift
@@ -11,6 +11,8 @@ struct MissionView: View {
     @State private var findings: [MissionFinding] = []
     @State private var observations: [LumaCore.StoreObservation] = []
     @State private var liveText: String = ""
+    @State private var pendingLiveText: String = ""
+    @State private var liveFlushTask: Task<Void, Never>?
     @State private var compactPane: CompactPane = .transcript
 
     #if canImport(UIKit)
@@ -53,8 +55,12 @@ struct MissionView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(.background)
         .task(id: missionID) { startObservations() }
+        .onDisappear { stopLiveObservation() }
         .onChange(of: turns.count) { oldCount, newCount in
             if newCount > oldCount, !liveText.isEmpty {
+                pendingLiveText = ""
+                liveFlushTask?.cancel()
+                liveFlushTask = nil
                 liveText = ""
             }
         }
@@ -85,7 +91,10 @@ struct MissionView: View {
 
     private func startObservations() {
         observations = []
+        liveFlushTask?.cancel()
+        liveFlushTask = nil
         liveText = engine.missionLiveText(missionID: missionID)
+        pendingLiveText = liveText
 
         turns = (try? engine.store.fetchMissionTurns(missionID: missionID)) ?? []
         actions = (try? engine.store.fetchMissionActions(missionID: missionID)) ?? []
@@ -105,13 +114,33 @@ struct MissionView: View {
             guard eventMissionID == missionID else { return }
             switch event {
             case .textDelta(let text):
-                liveText.append(text)
+                pendingLiveText.append(text)
+                scheduleLiveFlush()
             case .messageStop, .finalMessage:
+                pendingLiveText = ""
+                liveFlushTask?.cancel()
+                liveFlushTask = nil
                 liveText = ""
             default:
                 break
             }
         }
+    }
+
+    private func scheduleLiveFlush() {
+        guard liveFlushTask == nil else { return }
+        liveFlushTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 50_000_000)
+            guard !Task.isCancelled else { return }
+            liveText = pendingLiveText
+            liveFlushTask = nil
+        }
+    }
+
+    private func stopLiveObservation() {
+        engine.setMissionLiveDeltaSink(nil)
+        liveFlushTask?.cancel()
+        liveFlushTask = nil
     }
 }
 

--- a/Luma/WelcomeBackdrop.swift
+++ b/Luma/WelcomeBackdrop.swift
@@ -15,7 +15,8 @@ struct WelcomeBackdrop {
     func makeCoordinator() -> Renderer { Renderer() }
 
     fileprivate func install(into view: MTKView, coordinator: Renderer) {
-        view.device = MTLCreateSystemDefaultDevice()
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        view.device = device
         view.colorPixelFormat = .bgra8Unorm
         view.framebufferOnly = true
         view.isPaused = true
@@ -76,8 +77,11 @@ final class Renderer: NSObject, MTKViewDelegate {
               let descriptor = view.currentRenderPassDescriptor
         else { return }
 
-        let buffer = commandQueue!.makeCommandBuffer()!
-        let encoder = buffer.makeRenderCommandEncoder(descriptor: descriptor)!
+        guard let commandQueue,
+              let pipeline,
+              let buffer = commandQueue.makeCommandBuffer(),
+              let encoder = buffer.makeRenderCommandEncoder(descriptor: descriptor)
+        else { return }
 
         var uniforms = Uniforms(
             resolution: SIMD2(Float(view.drawableSize.width),
@@ -86,7 +90,7 @@ final class Renderer: NSObject, MTKViewDelegate {
             scheme: scheme
         )
 
-        encoder.setRenderPipelineState(pipeline!)
+        encoder.setRenderPipelineState(pipeline)
         encoder.setFragmentBytes(&uniforms, length: MemoryLayout<Uniforms>.stride, index: 0)
         encoder.drawPrimitives(type: .triangleStrip, vertexStart: 0, vertexCount: 4)
         encoder.endEncoding()
@@ -120,15 +124,15 @@ final class Renderer: NSObject, MTKViewDelegate {
     private func startDisplayLink() {
         displayLink?.invalidate()
         proxy.renderer = self
-        let link = makeScreenDisplayLink()
+        guard let link = makeScreenDisplayLink() else { return }
         link.add(to: .main, forMode: .common)
         displayLink = link
     }
 
-    private func makeScreenDisplayLink() -> CADisplayLink {
+    private func makeScreenDisplayLink() -> CADisplayLink? {
         let selector = #selector(DisplayLinkProxy.fire(_:))
         #if os(macOS)
-        return NSScreen.main!.displayLink(target: proxy, selector: selector)
+        return (view?.window?.screen ?? NSScreen.main)?.displayLink(target: proxy, selector: selector)
         #else
         return CADisplayLink(target: proxy, selector: selector)
         #endif

--- a/LumaGtk/Sources/LumaGtk/CustomInstrumentDefPane.swift
+++ b/LumaGtk/Sources/LumaGtk/CustomInstrumentDefPane.swift
@@ -137,7 +137,7 @@ final class CustomInstrumentDefPane {
         let path = file.path
         let content = draftContent
         Task { @MainActor in
-            engine.writeCustomInstrumentFile(defID: defID, path: path, content: content)
+            try? engine.writeCustomInstrumentFile(defID: defID, path: path, content: content)
             self.saveBar.setDirty(false)
         }
     }
@@ -148,7 +148,7 @@ final class CustomInstrumentDefPane {
         let path = file.path
         let content = draftContent
         Task { @MainActor in
-            engine.writeCustomInstrumentFile(defID: defID, path: path, content: content)
+            try? engine.writeCustomInstrumentFile(defID: defID, path: path, content: content)
         }
     }
 

--- a/LumaGtk/Sources/LumaGtk/CustomInstrumentFileDialogs.swift
+++ b/LumaGtk/Sources/LumaGtk/CustomInstrumentFileDialogs.swift
@@ -25,8 +25,12 @@ enum CustomInstrumentFileDialogs {
             },
             onCommit: { input in
                 Task { @MainActor in
-                    engine.writeCustomInstrumentFile(defID: defID, path: input, content: "")
-                    onCreated(input)
+                    do {
+                        let path = try engine.writeCustomInstrumentFile(defID: defID, path: input, content: "")
+                        onCreated(path)
+                    } catch {
+                        presentError(error, parent: parent)
+                    }
                 }
             }
         ).present(parent: parent)
@@ -57,11 +61,23 @@ enum CustomInstrumentFileDialogs {
             },
             onCommit: { input in
                 Task { @MainActor in
-                    engine.renameCustomInstrumentFile(defID: defID, from: oldPath, to: input)
-                    onRenamed(input)
+                    do {
+                        let renamedPath = try engine.renameCustomInstrumentFile(defID: defID, from: oldPath, to: input)
+                        onRenamed(renamedPath)
+                    } catch {
+                        presentError(error, parent: parent)
+                    }
                 }
             }
         ).present(parent: parent)
+    }
+
+    private static func presentError(_ error: Error, parent: Gtk.Window) {
+        let dialog = Adw.AlertDialog(heading: "Custom instrument error", body: error.localizedDescription)
+        dialog.addResponse(id: "ok", label: "OK")
+        dialog.setDefault(response: "ok")
+        dialog.setClose(response: "ok")
+        dialog.present(parent: parent)
     }
 }
 

--- a/LumaGtk/Sources/LumaGtk/MainWindow.swift
+++ b/LumaGtk/Sources/LumaGtk/MainWindow.swift
@@ -1546,7 +1546,11 @@ final class MainWindow: InstrumentUIHost {
     private func setCustomInstrumentEntrypoint(defID: UUID, path: String) {
         guard let engine else { return }
         Task { @MainActor in
-            engine.setCustomInstrumentEntrypoint(defID: defID, path: path)
+            do {
+                _ = try engine.setCustomInstrumentEntrypoint(defID: defID, path: path)
+            } catch {
+                self.presentCustomInstrumentError(message: error.localizedDescription)
+            }
         }
     }
 
@@ -1564,9 +1568,13 @@ final class MainWindow: InstrumentUIHost {
             let path = file.path
             let entrypoint = def.entrypoint
             Task { @MainActor in
-                engine.deleteCustomInstrumentFile(defID: defID, path: path)
-                if self.selection == .customInstrumentFile(defID, path) {
-                    self.select(.customInstrumentFile(defID, entrypoint))
+                do {
+                    try engine.deleteCustomInstrumentFile(defID: defID, path: path)
+                    if self.selection == .customInstrumentFile(defID, path) {
+                        self.select(.customInstrumentFile(defID, entrypoint))
+                    }
+                } catch {
+                    self.presentCustomInstrumentError(message: error.localizedDescription)
                 }
             }
         }
@@ -1592,6 +1600,14 @@ final class MainWindow: InstrumentUIHost {
         } catch {
             presentExportError(message: error.localizedDescription)
         }
+    }
+
+    private func presentCustomInstrumentError(message: String) {
+        let dialog = Adw.AlertDialog(heading: "Custom instrument error", body: message)
+        dialog.addResponse(id: "ok", label: "OK")
+        dialog.setDefault(response: "ok")
+        dialog.setClose(response: "ok")
+        dialog.present(parent: window)
     }
 
     private func presentExportError(message: String) {

--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,33 @@
 // swift-tools-version: 6.1
 
+import Foundation
 import PackageDescription
+
+#if canImport(Darwin)
+let manifestArgs = CommandLine.arguments
+let manifestFileno = manifestArgs.firstIndex(of: "-fileno").flatMap { index -> String? in
+    let valueIndex = manifestArgs.index(after: index)
+    guard valueIndex < manifestArgs.endIndex else { return nil }
+    return manifestArgs[valueIndex]
+}
+let usesXcodePackageResolution = manifestFileno != nil && manifestFileno != "4"
+#else
+let usesXcodePackageResolution = false
+#endif
+let lumaCoreExcludes = usesXcodePackageResolution ? [] : ["Generated"]
+let lumaCorePlugins: [Target.PluginUsage] = usesXcodePackageResolution ? [] : [
+    .plugin(name: "LumaBundlePlugin"),
+]
+let lumaBundlePluginTargets: [Target] = usesXcodePackageResolution ? [] : [
+    .plugin(
+        name: "LumaBundlePlugin",
+        capability: .buildTool(),
+        dependencies: [
+            .target(name: "LumaBundleCompiler"),
+        ],
+        path: "Plugins/LumaBundlePlugin"
+    ),
+]
 
 #if !canImport(Darwin)
 let cSoupTargets: [Target] = [
@@ -30,6 +57,7 @@ let package = Package(
     products: [
         .library(name: "LumaCore", targets: ["LumaCore"]),
         .executable(name: "luma-bundle-compiler", targets: ["LumaBundleCompiler"]),
+        .executable(name: "LumaBundleCompiler", targets: ["LumaBundleCompiler"]),
     ],
     dependencies: [
         .package(url: "https://github.com/frida/frida-swift", branch: "main"),
@@ -47,12 +75,14 @@ let package = Package(
                 .product(name: "SwiftyR2", package: "SwiftyR2"),
             ] + lumaCoreSoupDeps,
             path: "Sources/LumaCore",
+            exclude: lumaCoreExcludes,
             resources: [
                 .process("Resources"),
             ],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
-            ]
+            ],
+            plugins: lumaCorePlugins
         ),
         .executableTarget(
             name: "LumaBundleCompiler",
@@ -64,5 +94,5 @@ let package = Package(
                 .swiftLanguageMode(.v5),
             ]
         ),
-    ]
+    ] + lumaBundlePluginTargets
 )

--- a/Plugins/LumaBundlePlugin/Plugin.swift
+++ b/Plugins/LumaBundlePlugin/Plugin.swift
@@ -1,0 +1,55 @@
+import Foundation
+import PackagePlugin
+
+@main
+struct LumaBundlePlugin: BuildToolPlugin {
+    func createBuildCommands(context: PluginContext, target: Target) throws -> [Command] {
+        let compiler = try context.tool(named: "LumaBundleCompiler")
+        let packageRoot = context.package.directoryURL
+        let workDirectory = context.pluginWorkDirectoryURL
+        let swiftOutput = workDirectory.appending(path: "LumaAgent.swift")
+        let typingsOutput = workDirectory.appending(path: "LumaTypings.swift")
+        let stagingDirectory = workDirectory.appending(path: "AgentStaging", directoryHint: .isDirectory)
+
+        let inputFiles = [
+            "Package.swift",
+            "Agent/bundle.json",
+            "Agent/package.json",
+            "Agent/package-lock.json",
+            "Agent/core/console.ts",
+            "Agent/core/env.ts",
+            "Agent/core/instrument.ts",
+            "Agent/core/itrace.ts",
+            "Agent/core/luma.ts",
+            "Agent/core/memory.ts",
+            "Agent/core/modules.ts",
+            "Agent/core/pkg.ts",
+            "Agent/core/repl.ts",
+            "Agent/core/resolver.ts",
+            "Agent/core/symbolicate.ts",
+            "Agent/core/threads.ts",
+            "Agent/core/value.ts",
+            "Agent/instruments/codeshare.ts",
+            "Agent/instruments/drain-agent.ts",
+            "Agent/instruments/tracer.ts",
+            "Sources/LumaBundleCompiler/main.swift",
+        ].map { packageRoot.appending(path: $0) }
+
+        return [
+            .buildCommand(
+                displayName: "Generating Luma agent bundles",
+                executable: compiler.url,
+                arguments: [
+                    "--swift-out", swiftOutput.path,
+                    "--typings-out", typingsOutput.path,
+                    "--config", packageRoot.appending(path: "Agent/bundle.json").path,
+                    "--project-root", packageRoot.path,
+                    "--staging-dir", stagingDirectory.path,
+                    "--no-lockfile-update",
+                ],
+                inputFiles: inputFiles,
+                outputFiles: [swiftOutput, typingsOutput, stagingDirectory]
+            ),
+        ]
+    }
+}

--- a/Sources/LumaBundleCompiler/main.swift
+++ b/Sources/LumaBundleCompiler/main.swift
@@ -83,6 +83,7 @@ struct LumaBundleCompiler {
         var stagingDir: String?
         var manifestPath: String?
         var lockfilePath: String?
+        var shouldUpdateLockfile = true
         var entries: [Entry] = []
         var typingsEntries: [TypingsEntry] = []
         var packageSpecs: [String] = []
@@ -135,6 +136,9 @@ struct LumaBundleCompiler {
             case "--staging-dir":
                 guard !args.isEmpty else { throw ToolError.usage("Missing value for --staging-dir") }
                 stagingDir = args.removeFirst()
+
+            case "--no-lockfile-update":
+                shouldUpdateLockfile = false
 
             case "--package":
                 guard !args.isEmpty else { throw ToolError.usage("Missing value for --package") }
@@ -232,13 +236,24 @@ struct LumaBundleCompiler {
                 opts.role = .runtime
                 opts.specs = packageSpecs
 
-                _ = try await pm.install(options: opts)
+                do {
+                    _ = try await pm.install(options: opts)
+                } catch {
+                    fputs("[packages] frida install failed: \(error.localizedDescription)\n", stderr)
+                    fputs("[packages] falling back to npm\n", stderr)
+                    let stagingLockfile = URL(fileURLWithPath: stagingDir)
+                        .appendingPathComponent("package-lock.json").path
+                    try runNPMInstall(
+                        in: stagingDir,
+                        specs: packageSpecs,
+                        preferCleanInstall: packageSpecs.isEmpty && fm.fileExists(atPath: stagingLockfile))
+                }
 
                 fputs("[packages] done\n", stderr)
 
                 let stagingLockfile = URL(fileURLWithPath: stagingDir)
                     .appendingPathComponent("package-lock.json").path
-                if let dst = lockfilePath, fm.fileExists(atPath: stagingLockfile) {
+                if shouldUpdateLockfile, let dst = lockfilePath, fm.fileExists(atPath: stagingLockfile) {
                     if fm.fileExists(atPath: dst) {
                         try fm.removeItem(atPath: dst)
                     }
@@ -438,6 +453,7 @@ struct LumaBundleCompiler {
               --config <path>               JSON config listing packages, typings, agents, modules
               --project-root <path>         Root that agent entrypoints resolve against
               --staging-dir <path>          Directory for package installation and compilation
+              --no-lockfile-update          Do not copy the staging lockfile back to the config directory
               --swift-out <path>            Override agent output path from config
               --typings-out <path>          Override typings output path from config
               --package <spec>              Install an extra npm package
@@ -464,15 +480,20 @@ struct LumaBundleCompiler {
 
         let enumerator = fm.enumerator(
             at: srcDir,
-            includingPropertiesForKeys: [.isRegularFileKey],
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey],
             options: [.skipsHiddenFiles]
         )
 
         while let url = enumerator?.nextObject() as? URL {
-            let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+            let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isRegularFileKey])
+            if values.isDirectory == true, url.lastPathComponent == "node_modules" {
+                enumerator?.skipDescendants()
+                continue
+            }
             guard values.isRegularFile == true else { continue }
 
             let relPath = url.path.replacingOccurrences(of: srcDir.path + "/", with: "")
+            guard relPath != "package.json", relPath != "package-lock.json" else { continue }
             let dst = dstDir.appendingPathComponent(relPath)
 
             if fm.fileExists(atPath: dst.path) {
@@ -480,6 +501,29 @@ struct LumaBundleCompiler {
             }
             try fm.createDirectory(at: dst.deletingLastPathComponent(), withIntermediateDirectories: true)
             try fm.copyItem(at: url, to: dst)
+        }
+    }
+
+    static func runNPMInstall(in directory: String, specs: [String], preferCleanInstall: Bool) throws {
+        let args: [String]
+        if preferCleanInstall {
+            args = ["npm", "ci", "--ignore-scripts", "--no-audit", "--no-fund"]
+        } else {
+            args = ["npm", "install", "--ignore-scripts", "--no-audit", "--no-fund"] + specs
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = args
+        process.currentDirectoryURL = URL(fileURLWithPath: directory, isDirectory: true)
+        process.standardOutput = FileHandle.standardError
+        process.standardError = FileHandle.standardError
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw ToolError.buildFailed("npm \(args.dropFirst().joined(separator: " ")) exited with \(process.terminationStatus)")
         }
     }
 }

--- a/Sources/LumaCore/Agentic/ClaudeCodeProvider.swift
+++ b/Sources/LumaCore/Agentic/ClaudeCodeProvider.swift
@@ -13,6 +13,7 @@ public final class ClaudeCodeProvider: LLMProvider {
     public let descriptor: LLMProviderDescriptor
     private let executablePath: String
     private weak var engine: Engine?
+    private var initializedMissionSessionIDs: Set<UUID> = []
 
     public init(engine: Engine?, executablePath: String = "claude") {
         self.engine = engine
@@ -21,7 +22,7 @@ public final class ClaudeCodeProvider: LLMProvider {
             id: Self.providerID,
             displayName: "Claude Code (subprocess)",
             capabilities: LLMProviderCapabilities(
-                supported: engine != nil ? [.toolUse] : [],
+                supported: engine != nil ? [.streaming, .promptCaching, .toolUse] : [.streaming, .promptCaching],
                 reasoningEffortOptions: ["auto", "low", "medium", "high", "xhigh", "max"],
                 defaultReasoningEffort: "auto"
             ),
@@ -72,7 +73,8 @@ public final class ClaudeCodeProvider: LLMProvider {
         request: LLMTurnRequest,
         continuation: AsyncThrowingStream<LLMTurnEvent, Error>.Continuation
     ) async throws {
-        let prompt = renderConversation(request.messages)
+        let sessionPlan = makeSessionPlan(for: request)
+        let prompt = sessionPlan.prompt
         let systemText = renderSystemPrompt(request.systemBlocks)
 
         var arguments: [String] = [
@@ -82,7 +84,11 @@ public final class ClaudeCodeProvider: LLMProvider {
             "--output-format", "stream-json",
             "--include-partial-messages",
             "--verbose",
+            "--exclude-dynamic-system-prompt-sections",
         ]
+        if let sessionID = sessionPlan.sessionID {
+            arguments.append(contentsOf: ["--session-id", sessionID.uuidString])
+        }
         if !systemText.isEmpty {
             arguments.append(contentsOf: ["--append-system-prompt", systemText])
         }
@@ -185,6 +191,9 @@ public final class ClaudeCodeProvider: LLMProvider {
             let message = detail.isEmpty ? "claude exited with status \(process.terminationStatus)" : detail
             throw LLMProviderError.requestFailed(status: Int(process.terminationStatus), message: message)
         }
+        if let sessionID = sessionPlan.sessionID {
+            initializedMissionSessionIDs.insert(sessionID)
+        }
 
         let finalText = !assistantText.isEmpty ? assistantText : streamedText
         if !finalText.isEmpty {
@@ -278,6 +287,31 @@ public final class ClaudeCodeProvider: LLMProvider {
             }
         }
         return lines.joined(separator: "\n\n")
+    }
+
+    private struct ClaudeSessionPlan {
+        var prompt: String
+        var sessionID: UUID?
+    }
+
+    private func makeSessionPlan(for request: LLMTurnRequest) -> ClaudeSessionPlan {
+        guard let missionID = request.mission?.id else {
+            return ClaudeSessionPlan(prompt: renderConversation(request.messages), sessionID: nil)
+        }
+
+        if initializedMissionSessionIDs.contains(missionID), let latest = latestUserMessage(in: request.messages) {
+            return ClaudeSessionPlan(prompt: renderConversation([latest]), sessionID: missionID)
+        }
+
+        if request.messages.count <= 1 {
+            return ClaudeSessionPlan(prompt: renderConversation(request.messages), sessionID: missionID)
+        }
+
+        return ClaudeSessionPlan(prompt: renderConversation(request.messages), sessionID: nil)
+    }
+
+    private func latestUserMessage(in messages: [LLMMessage]) -> LLMMessage? {
+        messages.reversed().first { $0.role == .user }
     }
 
     private func renderSystemPrompt(_ blocks: [LLMContentBlock]) -> String {

--- a/Sources/LumaCore/Agentic/MCPServer.swift
+++ b/Sources/LumaCore/Agentic/MCPServer.swift
@@ -20,6 +20,8 @@ public final class MCPServer {
     private let resolveMission: MissionResolver
     private let toolNames: Set<String>
     private var pendingApprovals: [UUID: CheckedContinuation<ApprovalDecision, Never>] = [:]
+    private var cachedMCPTools: [[String: Any]]?
+    private var nextToolCallOrdinalByMission: [UUID: Int] = [:]
 
     #if canImport(Network)
     private let queue = DispatchQueue(label: "luma.mcp.server")
@@ -133,8 +135,9 @@ public final class MCPServer {
     }
 
     private func listMCPTools() -> [[String: Any]] {
+        if let cachedMCPTools { return cachedMCPTools }
         guard let engine else { return [] }
-        return engine.missionTools.specs()
+        let tools = engine.missionTools.specs()
             .filter { toolNames.isEmpty || toolNames.contains($0.name) }
             .map { spec -> [String: Any] in
                 let schema = (try? JSONSerialization.jsonObject(with: Data(spec.inputSchemaJSON.utf8)))
@@ -145,6 +148,8 @@ public final class MCPServer {
                     "inputSchema": schema,
                 ]
             }
+        cachedMCPTools = tools
+        return tools
     }
 
     private func handleToolCall(id rpcID: Any?, params: [String: Any]) async -> HTTPResponse {
@@ -167,8 +172,8 @@ public final class MCPServer {
 
         let sessionID = (arguments["session_id"] as? String).flatMap(UUID.init(uuidString:))
         let argsJSON = serializeArgs(arguments)
-        let priorActionCount = (try? engine.store.fetchMissionActions(missionID: mission.id))?.count ?? 0
-        let toolCallID = "t\(priorActionCount + 1)"
+        let toolCallOrdinal = nextToolCallOrdinal(for: mission.id, store: engine.store)
+        let toolCallID = "t\(toolCallOrdinal)"
 
         var action = MissionAction(
             missionID: mission.id,
@@ -259,6 +264,13 @@ public final class MCPServer {
             "content": [["type": "text", "text": text]],
             "isError": isError,
         ]
+    }
+
+    private func nextToolCallOrdinal(for missionID: UUID, store: ProjectStore) -> Int {
+        let previous = nextToolCallOrdinalByMission[missionID] ?? ((try? store.countMissionActions(missionID: missionID)) ?? 0)
+        let next = previous + 1
+        nextToolCallOrdinalByMission[missionID] = next
+        return next
     }
 
     private func serializeArgs(_ args: [String: Any]) -> String {

--- a/Sources/LumaCore/Agentic/MCPServer.swift
+++ b/Sources/LumaCore/Agentic/MCPServer.swift
@@ -249,8 +249,12 @@ public final class MCPServer {
 
     private func toolCallPayload(toolCallID: String, body: String, isError: Bool) -> [String: Any] {
         let envelope: [String: Any] = ["tool_call_id": toolCallID, "body": body]
-        let data = try! JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys])
-        let text = String(decoding: data, as: UTF8.self)
+        let text: String
+        if let data = try? JSONSerialization.data(withJSONObject: envelope, options: [.sortedKeys]) {
+            text = String(decoding: data, as: UTF8.self)
+        } else {
+            text = #"{"body":"Failed to serialize tool result.","tool_call_id":""}"#
+        }
         return [
             "content": [["type": "text", "text": text]],
             "isError": isError,
@@ -351,8 +355,18 @@ public final class MCPServer {
             if error != nil { conn.cancel(); return }
             var buffer = accumulated
             if let data { buffer.append(data) }
-            guard let parsed = parseHTTPRequest(buffer) else {
+            let parsed: ParsedRequest
+            switch parseHTTPRequest(buffer) {
+            case .complete(let request):
+                parsed = request
+            case .incomplete:
                 self.readRequest(on: conn, accumulated: buffer)
+                return
+            case .rejected(let response):
+                let bytes = encodeHTTPResponse(response)
+                conn.send(content: bytes, isComplete: true, completion: .contentProcessed { _ in
+                    conn.cancel()
+                })
                 return
             }
 
@@ -522,16 +536,39 @@ private struct ParsedRequest {
     let body: Data
 }
 
-private func parseHTTPRequest(_ buffer: Data) -> ParsedRequest? {
+private let maxHTTPRequestHeaderBytes = 16 * 1024
+private let maxHTTPRequestBodyBytes = 8 * 1024 * 1024
+
+private enum HTTPParseResult {
+    case complete(ParsedRequest)
+    case incomplete
+    case rejected(HTTPResponse)
+}
+
+private func parseHTTPRequest(_ buffer: Data) -> HTTPParseResult {
     guard let separator = "\r\n\r\n".data(using: .utf8),
         let headerEnd = buffer.range(of: separator)
-    else { return nil }
+    else {
+        if buffer.count > maxHTTPRequestHeaderBytes {
+            return .rejected(HTTPResponse(status: 431, body: Data("Request Header Fields Too Large".utf8), contentType: "text/plain"))
+        }
+        return .incomplete
+    }
     let headerData = buffer[..<headerEnd.lowerBound]
-    guard let header = String(data: headerData, encoding: .utf8) else { return nil }
+    guard headerData.count <= maxHTTPRequestHeaderBytes else {
+        return .rejected(HTTPResponse(status: 431, body: Data("Request Header Fields Too Large".utf8), contentType: "text/plain"))
+    }
+    guard let header = String(data: headerData, encoding: .utf8) else {
+        return .rejected(HTTPResponse(status: 400, body: Data("Bad Request".utf8), contentType: "text/plain"))
+    }
     let lines = header.components(separatedBy: "\r\n")
-    guard let requestLine = lines.first else { return nil }
+    guard let requestLine = lines.first else {
+        return .rejected(HTTPResponse(status: 400, body: Data("Bad Request".utf8), contentType: "text/plain"))
+    }
     let parts = requestLine.split(separator: " ", maxSplits: 2).map(String.init)
-    guard parts.count >= 2 else { return nil }
+    guard parts.count >= 2 else {
+        return .rejected(HTTPResponse(status: 400, body: Data("Bad Request".utf8), contentType: "text/plain"))
+    }
     let method = parts[0]
     let path = parts[1]
 
@@ -542,13 +579,24 @@ private func parseHTTPRequest(_ buffer: Data) -> ParsedRequest? {
         let value = line[line.index(after: colon)...].trimmingCharacters(in: .whitespaces)
         headers[String(name)] = value
     }
-    let contentLength = (headers["content-length"]).flatMap(Int.init) ?? 0
+    let contentLength: Int
+    if let value = headers["content-length"] {
+        guard let parsed = Int(value), parsed >= 0 else {
+            return .rejected(HTTPResponse(status: 400, body: Data("Bad Request".utf8), contentType: "text/plain"))
+        }
+        contentLength = parsed
+    } else {
+        contentLength = 0
+    }
+    guard contentLength <= maxHTTPRequestBodyBytes else {
+        return .rejected(HTTPResponse(status: 413, body: Data("Payload Too Large".utf8), contentType: "text/plain"))
+    }
 
     let bodyStart = headerEnd.upperBound
     let available = buffer.count - bodyStart
-    guard available >= contentLength else { return nil }
+    guard available >= contentLength else { return .incomplete }
     let body = Data(buffer[bodyStart..<(bodyStart + contentLength)])
-    return ParsedRequest(method: method, path: path, headers: headers, body: body)
+    return .complete(ParsedRequest(method: method, path: path, headers: headers, body: body))
 }
 
 private func encodeHTTPResponse(_ response: HTTPResponse) -> Data {
@@ -558,7 +606,9 @@ private func encodeHTTPResponse(_ response: HTTPResponse) -> Data {
     case 204: reason = "No Content"
     case 400: reason = "Bad Request"
     case 401: reason = "Unauthorized"
+    case 413: reason = "Payload Too Large"
     case 405: reason = "Method Not Allowed"
+    case 431: reason = "Request Header Fields Too Large"
     case 500: reason = "Internal Server Error"
     default: reason = "Status"
     }

--- a/Sources/LumaCore/Agentic/MissionExecutor.swift
+++ b/Sources/LumaCore/Agentic/MissionExecutor.swift
@@ -161,7 +161,7 @@ public final class MissionExecutor {
                 await runAction(action, mission: mission)
             }
 
-            let stillPending = (try? store.fetchMissionActions(missionID: mission.id))?.contains(where: { $0.status == .pending }) ?? false
+            let stillPending = (try? store.hasPendingMissionActions(missionID: mission.id)) ?? false
             if stillPending {
                 mission.status = .awaitingApproval
                 persistMission(mission)

--- a/Sources/LumaCore/Agentic/MissionTools.swift
+++ b/Sources/LumaCore/Agentic/MissionTools.swift
@@ -432,9 +432,9 @@ public enum MissionTools {
     private static func registerListModules(in catalog: ToolCatalog, engine: Engine) {
         let spec = ActionSpec(
             name: "list_modules",
-            description: "List loaded modules (libraries, frameworks, main binary) in the target process. Real processes can have ~1000 modules, so the result is filtered and capped by default. Pass 'match' (case-insensitive substring matched against name and path) to narrow, 'limit' to cap, and 'detail' to choose projection. Default detail 'summary' returns {name, base}; 'full' adds size and path. Response shape: {total, matched, returned, truncated, modules}.",
+            description: "List loaded modules (libraries, frameworks, main binary) in the target process. Real processes can have ~1000 modules, so the result is filtered and capped by default. Pass 'match' (case-insensitive substring matched against name and path) to narrow, 'offset'/'limit' to page, and 'detail' to choose projection. Default detail 'summary' returns {name, base}; 'full' adds size and path. Response shape: {total, matched, offset, returned, truncated, modules}.",
             inputSchemaJSON: """
-                {"type":"object","properties":{"session_id":{"type":"string","description":"Session UUID to query"},"match":{"type":"string","description":"Case-insensitive substring matched against module name and path. Omit to consider all modules."},"limit":{"type":"integer","minimum":1,"maximum":500,"description":"Max modules to return (default 64)"},"detail":{"type":"string","enum":["summary","full"],"description":"'summary' = name+base only (default). 'full' adds size and path."}},"required":["session_id"],"additionalProperties":false}
+                {"type":"object","properties":{"session_id":{"type":"string","description":"Session UUID to query"},"match":{"type":"string","description":"Case-insensitive substring matched against module name and path. Omit to consider all modules."},"offset":{"type":"integer","minimum":0,"description":"Number of matched modules to skip before returning rows (default 0)."},"limit":{"type":"integer","minimum":1,"maximum":500,"description":"Max modules to return (default 64)"},"detail":{"type":"string","enum":["summary","full"],"description":"'summary' = name+base only (default). 'full' adds size and path."}},"required":["session_id"],"additionalProperties":false}
                 """,
             isObserve: true,
             requiresSession: true
@@ -455,9 +455,10 @@ public enum MissionTools {
             } else {
                 matched = all
             }
+            let offset = max(0, (invocation.args["offset"] as? Int) ?? 0)
             let limit = max(1, min(500, (invocation.args["limit"] as? Int) ?? 64))
-            let returned = Array(matched.prefix(limit))
-            let truncated = matched.count > returned.count
+            let returned = Array(matched.dropFirst(offset).prefix(limit))
+            let truncated = matched.count > offset + returned.count
             let detail = (invocation.args["detail"] as? String) ?? "summary"
             let modulesJSON: [[String: Any]] = returned.map { m in
                 var entry: [String: Any] = [
@@ -473,6 +474,7 @@ public enum MissionTools {
             let payload: [String: Any] = [
                 "total": all.count,
                 "matched": matched.count,
+                "offset": offset,
                 "returned": returned.count,
                 "truncated": truncated,
                 "modules": modulesJSON,
@@ -481,7 +483,7 @@ public enum MissionTools {
             if let needle {
                 summary = "Matched \(matched.count)/\(all.count) module\(matched.count == 1 ? "" : "s") for '\(needle)'\(truncated ? " (returning \(returned.count))" : "")"
             } else {
-                summary = "\(all.count) module\(all.count == 1 ? "" : "s") loaded\(truncated ? "; returning first \(returned.count)" : "")"
+                summary = "\(all.count) module\(all.count == 1 ? "" : "s") loaded\(truncated ? "; returning \(returned.count) from offset \(offset)" : "")"
             }
             return makeResult(jsonObject: payload, summary: summary)
         }
@@ -492,9 +494,9 @@ public enum MissionTools {
     private static func registerListThreads(in catalog: ToolCatalog, engine: Engine) {
         let spec = ActionSpec(
             name: "list_threads",
-            description: "List the target process's known threads: tid, name (when assigned), and entrypoint routine address. Live for attached sessions; falls back to the last cached snapshot when the session is detached.",
+            description: "List the target process's known threads. Thread-heavy processes can have hundreds of rows, so the result is capped by default. Pass 'offset'/'limit' to page and 'detail' to choose projection. Default detail 'summary' returns {id, name}; 'full' also includes entrypoint. Live for attached sessions; falls back to the last cached snapshot when the session is detached. Response shape: {total, offset, returned, truncated, threads}.",
             inputSchemaJSON: """
-                {"type":"object","properties":{"session_id":{"type":"string"}},"required":["session_id"],"additionalProperties":false}
+                {"type":"object","properties":{"session_id":{"type":"string"},"offset":{"type":"integer","minimum":0,"description":"Number of threads to skip before returning rows (default 0)."},"limit":{"type":"integer","minimum":1,"maximum":500,"description":"Max threads to return (default 64)."},"detail":{"type":"string","enum":["summary","full"],"description":"'summary' = id+name only (default). 'full' adds entrypoint."}},"required":["session_id"],"additionalProperties":false}
                 """,
             isObserve: true,
             requiresSession: true
@@ -508,9 +510,37 @@ public enum MissionTools {
             guard let threads = liveThreads ?? cached else {
                 return errorResult("no thread data for session \(sessionID)", code: .notFound)
             }
-            let array: [[String: Any]] = threads.map { $0.toJSON() }
-            return makeResult(jsonObject: array, summary: "Listed \(threads.count) thread\(threads.count == 1 ? "" : "s")")
+            let offset = max(0, (invocation.args["offset"] as? Int) ?? 0)
+            let limit = max(1, min(500, (invocation.args["limit"] as? Int) ?? 64))
+            let returned = Array(threads.dropFirst(offset).prefix(limit))
+            let truncated = threads.count > offset + returned.count
+            let detail = (invocation.args["detail"] as? String) ?? "summary"
+            let array: [[String: Any]] = returned.map { threadJSON($0, detail: detail) }
+            let payload: [String: Any] = [
+                "total": threads.count,
+                "offset": offset,
+                "returned": returned.count,
+                "truncated": truncated,
+                "threads": array,
+            ]
+            let suffix = truncated ? "; returning \(returned.count) from offset \(offset)" : ""
+            return makeResult(jsonObject: payload, summary: "Listed \(threads.count) thread\(threads.count == 1 ? "" : "s")\(suffix)")
         }
+    }
+
+    private static func threadJSON(_ thread: ProcessThread, detail: String) -> [String: Any] {
+        var obj: [String: Any] = ["id": Int(thread.id)]
+        if let name = thread.name {
+            obj["name"] = name
+        }
+        if detail == "full", let entrypoint = thread.entrypoint {
+            var ep: [String: Any] = ["routine": String(format: "0x%llx", entrypoint.routine)]
+            if let parameter = entrypoint.parameter {
+                ep["parameter"] = String(format: "0x%llx", parameter)
+            }
+            obj["entrypoint"] = ep
+        }
+        return obj
     }
 
     // MARK: - list_session_instruments

--- a/Sources/LumaCore/Agentic/MissionTools.swift
+++ b/Sources/LumaCore/Agentic/MissionTools.swift
@@ -1940,14 +1940,18 @@ public enum MissionTools {
                 guard let content = invocation.args["content"] as? String else {
                     return errorResult("missing content", code: .invalidInput)
                 }
-                engine.writeCustomInstrumentFile(defID: defID, path: path, content: content)
-                await engine.awaitCustomInstrumentReload(defID: defID)
-                return customInstrumentEditResult(
-                    engine: engine,
-                    defID: defID,
-                    summaryPrefix: "Wrote \(path)",
-                    extraFields: ["path": path]
-                )
+                do {
+                    let writtenPath = try engine.writeCustomInstrumentFile(defID: defID, path: path, content: content)
+                    await engine.awaitCustomInstrumentReload(defID: defID)
+                    return customInstrumentEditResult(
+                        engine: engine,
+                        defID: defID,
+                        summaryPrefix: "Wrote \(writtenPath)",
+                        extraFields: ["path": writtenPath]
+                    )
+                } catch {
+                    return errorResult(error.localizedDescription, code: .invalidInput)
+                }
             }
         }
     }
@@ -1987,14 +1991,18 @@ public enum MissionTools {
                 case .failure(let message):
                     return errorResult(message, code: .invalidInput)
                 }
-                engine.writeCustomInstrumentFile(defID: defID, path: file.path, content: updated)
-                await engine.awaitCustomInstrumentReload(defID: defID)
-                return customInstrumentEditResult(
-                    engine: engine,
-                    defID: defID,
-                    summaryPrefix: "Edited \(file.path) lines \(startLine)–\(endLine)",
-                    extraFields: ["path": file.path, "line_count": lineCount(of: updated)]
-                )
+                do {
+                    let writtenPath = try engine.writeCustomInstrumentFile(defID: defID, path: file.path, content: updated)
+                    await engine.awaitCustomInstrumentReload(defID: defID)
+                    return customInstrumentEditResult(
+                        engine: engine,
+                        defID: defID,
+                        summaryPrefix: "Edited \(writtenPath) lines \(startLine)–\(endLine)",
+                        extraFields: ["path": writtenPath, "line_count": lineCount(of: updated)]
+                    )
+                } catch {
+                    return errorResult(error.localizedDescription, code: .invalidInput)
+                }
             }
         }
     }
@@ -2014,14 +2022,18 @@ public enum MissionTools {
                 if def.entrypoint == file.path {
                     return errorResult("cannot delete entrypoint '\(file.path)' — re-point with set_custom_instrument_entrypoint first", code: .invalidInput)
                 }
-                engine.deleteCustomInstrumentFile(defID: defID, path: file.path)
-                await engine.awaitCustomInstrumentReload(defID: defID)
-                return customInstrumentEditResult(
-                    engine: engine,
-                    defID: defID,
-                    summaryPrefix: "Deleted \(file.path)",
-                    extraFields: ["path": file.path]
-                )
+                do {
+                    try engine.deleteCustomInstrumentFile(defID: defID, path: file.path)
+                    await engine.awaitCustomInstrumentReload(defID: defID)
+                    return customInstrumentEditResult(
+                        engine: engine,
+                        defID: defID,
+                        summaryPrefix: "Deleted \(file.path)",
+                        extraFields: ["path": file.path]
+                    )
+                } catch {
+                    return errorResult(error.localizedDescription, code: .invalidInput)
+                }
             }
         }
     }
@@ -2046,14 +2058,18 @@ public enum MissionTools {
                 guard engine.customInstruments.file(defID: defID, path: from) != nil else {
                     return errorResult("no file '\(from)'", code: .notFound)
                 }
-                engine.renameCustomInstrumentFile(defID: defID, from: from, to: to)
-                await engine.awaitCustomInstrumentReload(defID: defID)
-                return customInstrumentEditResult(
-                    engine: engine,
-                    defID: defID,
-                    summaryPrefix: "Renamed \(from) → \(to)",
-                    extraFields: ["from": from, "to": to]
-                )
+                do {
+                    let renamedPath = try engine.renameCustomInstrumentFile(defID: defID, from: from, to: to)
+                    await engine.awaitCustomInstrumentReload(defID: defID)
+                    return customInstrumentEditResult(
+                        engine: engine,
+                        defID: defID,
+                        summaryPrefix: "Renamed \(from) → \(renamedPath)",
+                        extraFields: ["from": from, "to": renamedPath]
+                    )
+                } catch {
+                    return errorResult(error.localizedDescription, code: .invalidInput)
+                }
             }
         }
     }
@@ -2070,14 +2086,18 @@ public enum MissionTools {
         )
         catalog.register(spec: spec) { [weak engine] invocation in
             await withResolvedCustomInstrumentFile(invocation.args, engine: engine) { engine, defID, _, file in
-                engine.setCustomInstrumentEntrypoint(defID: defID, path: file.path)
-                await engine.awaitCustomInstrumentReload(defID: defID)
-                return customInstrumentEditResult(
-                    engine: engine,
-                    defID: defID,
-                    summaryPrefix: "Entrypoint set to \(file.path)",
-                    extraFields: ["entrypoint": file.path]
-                )
+                do {
+                    let entrypoint = try engine.setCustomInstrumentEntrypoint(defID: defID, path: file.path)
+                    await engine.awaitCustomInstrumentReload(defID: defID)
+                    return customInstrumentEditResult(
+                        engine: engine,
+                        defID: defID,
+                        summaryPrefix: "Entrypoint set to \(entrypoint)",
+                        extraFields: ["entrypoint": entrypoint]
+                    )
+                } catch {
+                    return errorResult(error.localizedDescription, code: .invalidInput)
+                }
             }
         }
     }

--- a/Sources/LumaCore/Agentic/ServerSentEvents.swift
+++ b/Sources/LumaCore/Agentic/ServerSentEvents.swift
@@ -11,7 +11,9 @@ struct ServerSentEventStream {
 func openServerSentEventStream(session: URLSession, request: URLRequest) async throws -> ServerSentEventStream {
     #if canImport(FoundationNetworking)
     let (data, response) = try await session.data(for: request)
-    let http = response as! HTTPURLResponse
+    guard let http = response as? HTTPURLResponse else {
+        throw LumaCoreError.protocolViolation("Server sent an invalid HTTP response.")
+    }
     let body = String(decoding: data, as: UTF8.self)
     let lines = AsyncThrowingStream<String, Error> { continuation in
         for line in body.split(separator: "\n", omittingEmptySubsequences: false) {
@@ -22,7 +24,9 @@ func openServerSentEventStream(session: URLSession, request: URLRequest) async t
     return ServerSentEventStream(http: http, lines: lines)
     #else
     let (bytes, response) = try await session.bytes(for: request)
-    let http = response as! HTTPURLResponse
+    guard let http = response as? HTTPURLResponse else {
+        throw LumaCoreError.protocolViolation("Server sent an invalid HTTP response.")
+    }
     let lines = AsyncThrowingStream<String, Error> { continuation in
         let task = Task {
             do {

--- a/Sources/LumaCore/Agentic/ToolCatalog.swift
+++ b/Sources/LumaCore/Agentic/ToolCatalog.swift
@@ -7,6 +7,8 @@ public final class ToolCatalog {
     private var specsByName: [String: ActionSpec] = [:]
     private var executorsByName: [String: Executor] = [:]
     private var registrationOrder: [String] = []
+    private var cachedSpecs: [ActionSpec]?
+    private var cachedToolSpecs: [LLMToolSpec]?
 
     public init() {}
 
@@ -16,12 +18,16 @@ public final class ToolCatalog {
         }
         specsByName[spec.name] = spec
         executorsByName[spec.name] = executor
+        cachedSpecs = nil
+        cachedToolSpecs = nil
     }
 
     public func unregister(name: String) {
         specsByName.removeValue(forKey: name)
         executorsByName.removeValue(forKey: name)
         registrationOrder.removeAll { $0 == name }
+        cachedSpecs = nil
+        cachedToolSpecs = nil
     }
 
     public func spec(named name: String) -> ActionSpec? {
@@ -29,14 +35,20 @@ public final class ToolCatalog {
     }
 
     public func specs() -> [ActionSpec] {
-        registrationOrder.compactMap { specsByName[$0] }
+        if let cachedSpecs { return cachedSpecs }
+        let specs = registrationOrder.compactMap { specsByName[$0] }
+        cachedSpecs = specs
+        return specs
     }
 
     public func toolSpecs() -> [LLMToolSpec] {
+        if let cachedToolSpecs { return cachedToolSpecs }
         let specs = self.specs()
-        return specs.enumerated().map { index, spec in
+        let toolSpecs = specs.enumerated().map { index, spec in
             spec.toToolSpec(cacheBoundary: index == specs.count - 1)
         }
+        cachedToolSpecs = toolSpecs
+        return toolSpecs
     }
 
     public func execute(_ name: String, invocation: ActionInvocation) async throws -> ActionResult {

--- a/Sources/LumaCore/CompilerWorkspace.swift
+++ b/Sources/LumaCore/CompilerWorkspace.swift
@@ -390,25 +390,41 @@ public struct CompilerDiagnostic: Sendable, Hashable, CustomStringConvertible {
     }
 
     static func parse(_ payload: Any, pathDisplay: ((String) -> String)?) -> [CompilerDiagnostic] {
-        let entries = payload as! [[String: Any]]
+        guard let entries = payload as? [[String: Any]] else { return [] }
         return entries.map { decode($0, pathDisplay: pathDisplay) }
     }
 
     private static func decode(_ obj: [String: Any], pathDisplay: ((String) -> String)?) -> CompilerDiagnostic {
         return CompilerDiagnostic(
-            category: obj["category"] as! String,
-            code: Int(obj["code"] as! Int64),
-            location: (obj["file"] as? [String: Any]).map { decodeLocation($0, pathDisplay: pathDisplay) },
-            text: obj["text"] as! String
+            category: obj["category"] as? String ?? "error",
+            code: decodeInt(obj["code"]) ?? -1,
+            location: (obj["file"] as? [String: Any]).flatMap { decodeLocation($0, pathDisplay: pathDisplay) },
+            text: obj["text"] as? String ?? "Compiler returned an invalid diagnostic payload."
         )
     }
 
-    private static func decodeLocation(_ obj: [String: Any], pathDisplay: ((String) -> String)?) -> Location {
-        let rawPath = obj["path"] as! String
+    private static func decodeLocation(_ obj: [String: Any], pathDisplay: ((String) -> String)?) -> Location? {
+        guard let rawPath = obj["path"] as? String,
+            let line = decodeInt(obj["line"]),
+            let character = decodeInt(obj["character"])
+        else { return nil }
         return Location(
             path: pathDisplay?(rawPath) ?? rawPath,
-            line: Int(obj["line"] as! Int64),
-            character: Int(obj["character"] as! Int64)
+            line: line,
+            character: character
         )
+    }
+
+    private static func decodeInt(_ raw: Any?) -> Int? {
+        switch raw {
+        case let value as Int:
+            return value
+        case let value as Int64:
+            return Int(value)
+        case let value as Double:
+            return Int(exactly: value)
+        default:
+            return nil
+        }
     }
 }

--- a/Sources/LumaCore/Engine.swift
+++ b/Sources/LumaCore/Engine.swift
@@ -5867,7 +5867,7 @@ public func deleteCustomInstrument(_ defID: UUID) async {
 
         await missionExecutor.runActionByID(approved.id, mission: mission)
 
-        let stillPending = (try? store.fetchMissionActions(missionID: approved.missionID))?.contains(where: { $0.status == .pending }) ?? false
+        let stillPending = (try? store.hasPendingMissionActions(missionID: approved.missionID)) ?? false
         if !stillPending {
             missionExecutor.resume(missionID: approved.missionID)
         }
@@ -5888,7 +5888,7 @@ public func deleteCustomInstrument(_ defID: UUID) async {
         try? store.save(action)
         collaboration.enqueueMissionAction(action)
 
-        let stillPending = (try? store.fetchMissionActions(missionID: action.missionID))?.contains(where: { $0.status == .pending }) ?? false
+        let stillPending = (try? store.hasPendingMissionActions(missionID: action.missionID)) ?? false
         if !stillPending {
             missionExecutor.resume(missionID: action.missionID)
         }
@@ -5897,7 +5897,7 @@ public func deleteCustomInstrument(_ defID: UUID) async {
     public func cancelAddressNoteReply(sessionID: UUID) async {
         activeNoteReplyTasks[sessionID]?.cancel()
         guard let missionID = sessionUIStates[sessionID]?.ambientMissionID else { return }
-        let pending = (try? store.fetchMissionActions(missionID: missionID))?.filter { $0.status == .pending } ?? []
+        let pending = (try? store.fetchPendingMissionActions(missionID: missionID)) ?? []
         for action in pending {
             await rejectMissionAction(actionID: action.id, reason: "User cancelled the note reply.")
         }
@@ -5922,7 +5922,7 @@ public func deleteCustomInstrument(_ defID: UUID) async {
         try? store.save(action)
         collaboration.enqueueMissionAction(action)
 
-        let stillPending = (try? store.fetchMissionActions(missionID: action.missionID))?.contains(where: { $0.status == .pending }) ?? false
+        let stillPending = (try? store.hasPendingMissionActions(missionID: action.missionID)) ?? false
         if !stillPending {
             missionExecutor.resume(missionID: action.missionID)
         }

--- a/Sources/LumaCore/Engine.swift
+++ b/Sources/LumaCore/Engine.swift
@@ -904,7 +904,7 @@ public final class Engine {
             guard let self else { return }
             switch op {
             case .upsert(let u):
-                var bundle = u.bundle
+                guard var bundle = try? Self.validatedCustomInstrumentBundle(u.bundle) else { return }
                 bundle.def.normalize()
                 try? self.store.save(bundle.def)
                 try? self.store.replaceCustomInstrumentFiles(defID: bundle.def.id, files: bundle.files)
@@ -1842,7 +1842,7 @@ public final class Engine {
             }
 
             try await node.loadPackages([entry])
-            node.loadedPackageNames.insert(entry["name"] as! String)
+            node.loadedPackageNames.insert(package.name)
         } catch {
             var message = "Failed to load package \(package.name): \(userFacingMessage(error))"
             if let compile = error as? CompileFailure, !compile.diagnostics.isEmpty {
@@ -4172,7 +4172,6 @@ public final class Engine {
 
         let options = BuildOptions()
         options.projectRoot = paths.root.path
-        options.typeCheck = .none
         options.sourceMaps = .omitted
         options.compression = .terser
 
@@ -4423,16 +4422,16 @@ public final class Engine {
         try fm.createDirectory(at: dirURL, withIntermediateDirectories: true)
 
         for file in files {
-            let fileURL = dirURL.appendingPathComponent(file.path)
+            let path = try CustomInstrumentFile.validateRelativePath(file.path)
+            let fileURL = dirURL.appendingPathComponent(path)
             try fm.createDirectory(at: fileURL.deletingLastPathComponent(), withIntermediateDirectories: true)
             try file.content.write(to: fileURL)
         }
 
-        let entryRelPath = "\(dirRelPath)/\(entrypoint)"
+        let entryRelPath = "\(dirRelPath)/\(try CustomInstrumentFile.validateRelativePath(entrypoint))"
 
         let options = BuildOptions()
         options.projectRoot = paths.root.path
-        options.typeCheck = .none
         options.sourceMaps = .omitted
         options.compression = .terser
 
@@ -4472,9 +4471,30 @@ public final class Engine {
             if relativePath == "manifest.json" { continue }
             if relativePath == iconPath { continue }
             let data = try Data(contentsOf: url)
-            result.append((path: relativePath, content: data))
+            result.append((path: try CustomInstrumentFile.validateRelativePath(relativePath), content: data))
         }
         return result
+    }
+
+    private static func validatedCustomInstrumentBundle(_ bundle: CustomInstrumentBundle) throws -> CustomInstrumentBundle {
+        let files = try bundle.files.map { file in
+            CustomInstrumentFile(
+                defID: file.defID,
+                path: try CustomInstrumentFile.validateRelativePath(file.path),
+                content: file.content
+            )
+        }
+        var def = bundle.def
+        def.entrypoint = try validatedEntrypoint(def.entrypoint, files: files)
+        return CustomInstrumentBundle(def: def, files: files)
+    }
+
+    private static func validatedEntrypoint(_ entrypoint: String, files: [CustomInstrumentFile]) throws -> String {
+        let path = try CustomInstrumentFile.validateRelativePath(entrypoint)
+        guard files.contains(where: { $0.path == path }) else {
+            throw LumaCoreError.invalidArgument("Entrypoint '\(path)' does not exist in this custom instrument.")
+        }
+        return path
     }
 
     private func customInstrumentDef(for config: CustomInstrumentConfig) -> CustomInstrumentDef? {
@@ -4530,38 +4550,60 @@ public final class Engine {
         scheduleCustomInstrumentReload(defID: updated.id)
     }
 
-    public func writeCustomInstrumentFile(defID: UUID, path: String, content: String) {
-        let file = CustomInstrumentFile(defID: defID, path: path, content: content)
-        try? store.save(file)
-        try? store.save(touchUpdatedAt(defID: defID))
+    @discardableResult
+    public func writeCustomInstrumentFile(defID: UUID, path: String, content: String) throws -> String {
+        let validatedPath = try CustomInstrumentFile.validateRelativePath(path)
+        let file = CustomInstrumentFile(defID: defID, path: validatedPath, content: content)
+        _ = try requireCustomInstrumentDef(defID: defID)
+        try store.save(file)
+        try store.save(touchUpdatedAt(defID: defID))
         broadcastCustomInstrumentUpsert(defID: defID)
         scheduleCustomInstrumentReload(defID: defID)
+        return validatedPath
     }
 
-    public func deleteCustomInstrumentFile(defID: UUID, path: String) {
-        try? store.deleteCustomInstrumentFile(defID: defID, path: path)
-        try? store.save(touchUpdatedAt(defID: defID))
-        broadcastCustomInstrumentUpsert(defID: defID)
-        scheduleCustomInstrumentReload(defID: defID)
-    }
-
-    public func renameCustomInstrumentFile(defID: UUID, from: String, to: String) {
-        try? store.renameCustomInstrumentFile(defID: defID, from: from, to: to)
-        var def = touchUpdatedAt(defID: defID)
-        if def.entrypoint == from {
-            def.entrypoint = to
+    public func deleteCustomInstrumentFile(defID: UUID, path: String) throws {
+        let validatedPath = try CustomInstrumentFile.validateRelativePath(path)
+        let def = try requireCustomInstrumentDef(defID: defID)
+        guard def.entrypoint != validatedPath else {
+            throw LumaCoreError.invalidOperation("Cannot delete the entrypoint file.")
         }
-        try? store.save(def)
+        try store.deleteCustomInstrumentFile(defID: defID, path: validatedPath)
+        try store.save(touchUpdatedAt(defID: defID))
         broadcastCustomInstrumentUpsert(defID: defID)
         scheduleCustomInstrumentReload(defID: defID)
     }
 
-    public func setCustomInstrumentEntrypoint(defID: UUID, path: String) {
-        var def = touchUpdatedAt(defID: defID)
-        def.entrypoint = path
-        try? store.save(def)
+    @discardableResult
+    public func renameCustomInstrumentFile(defID: UUID, from: String, to: String) throws -> String {
+        let fromPath = try CustomInstrumentFile.validateRelativePath(from)
+        let toPath = try CustomInstrumentFile.validateRelativePath(to)
+        guard try store.fetchCustomInstrumentFile(defID: defID, path: fromPath) != nil else {
+            throw LumaCoreError.invalidArgument("No file '\(fromPath)' in this custom instrument.")
+        }
+        try store.renameCustomInstrumentFile(defID: defID, from: fromPath, to: toPath)
+        var def = try touchUpdatedAt(defID: defID)
+        if def.entrypoint == fromPath {
+            def.entrypoint = toPath
+        }
+        try store.save(def)
         broadcastCustomInstrumentUpsert(defID: defID)
         scheduleCustomInstrumentReload(defID: defID)
+        return toPath
+    }
+
+    @discardableResult
+    public func setCustomInstrumentEntrypoint(defID: UUID, path: String) throws -> String {
+        let validatedPath = try CustomInstrumentFile.validateRelativePath(path)
+        guard try store.fetchCustomInstrumentFile(defID: defID, path: validatedPath) != nil else {
+            throw LumaCoreError.invalidArgument("No file '\(validatedPath)' in this custom instrument.")
+        }
+        var def = try touchUpdatedAt(defID: defID)
+        def.entrypoint = validatedPath
+        try store.save(def)
+        broadcastCustomInstrumentUpsert(defID: defID)
+        scheduleCustomInstrumentReload(defID: defID)
+        return validatedPath
     }
 
     private func scheduleCustomInstrumentReload(defID: UUID) {
@@ -4592,8 +4634,18 @@ public final class Engine {
         }
     }
 
-    private func touchUpdatedAt(defID: UUID) -> CustomInstrumentDef {
-        var def = customInstruments.def(withId: defID) ?? (try? store.fetchCustomInstrumentDef(id: defID))!
+    private func requireCustomInstrumentDef(defID: UUID) throws -> CustomInstrumentDef {
+        if let cached = customInstruments.def(withId: defID) {
+            return cached
+        }
+        if let stored = try store.fetchCustomInstrumentDef(id: defID) {
+            return stored
+        }
+        throw LumaCoreError.invalidArgument("No custom instrument with id \(defID).")
+    }
+
+    private func touchUpdatedAt(defID: UUID) throws -> CustomInstrumentDef {
+        var def = try requireCustomInstrumentDef(defID: defID)
         def.updatedAt = Date()
         return def
     }
@@ -4611,7 +4663,7 @@ public final class Engine {
         case .symbolic(let id):
             icon = .symbolic(id)
         case .file(let path):
-            let iconURL = folderURL.appendingPathComponent(path)
+            let iconURL = folderURL.appendingPathComponent(try CustomInstrumentFile.validateRelativePath(path))
             icon = .pixels(try Data(contentsOf: iconURL))
         }
 
@@ -4619,22 +4671,26 @@ public final class Engine {
 
         let now = Date()
         let defID = UUID()
+        let files = try packFiles.map { pf in
+            CustomInstrumentFile(
+                defID: defID,
+                path: try CustomInstrumentFile.validateRelativePath(pf.path),
+                content: String(decoding: pf.content, as: UTF8.self)
+            )
+        }
+
         var def = CustomInstrumentDef(
             id: defID,
             name: uniquedCustomInstrumentName(manifest.name),
             icon: icon,
             compatibility: manifest.compatibility,
-            entrypoint: manifest.entrypoint,
+            entrypoint: try Self.validatedEntrypoint(manifest.entrypoint, files: files),
             features: manifest.features,
             widgets: manifest.widgets,
             createdAt: now,
             updatedAt: now
         )
         def.normalize()
-
-        let files = packFiles.map { pf in
-            CustomInstrumentFile(defID: defID, path: pf.path, content: String(decoding: pf.content, as: UTF8.self))
-        }
 
         try store.save(def)
         try store.replaceCustomInstrumentFiles(defID: defID, files: files)
@@ -4657,11 +4713,20 @@ public final class Engine {
             iconAttachment = HookPackBundle.IconAttachment(filename: iconName, data: data)
         }
 
+        let defFiles = try customInstruments.files(forDefID: def.id).map { file in
+            CustomInstrumentFile(
+                defID: file.defID,
+                path: try CustomInstrumentFile.validateRelativePath(file.path),
+                content: file.content
+            )
+        }
+        let entrypoint = try Self.validatedEntrypoint(def.entrypoint, files: defFiles)
+
         let manifest = HookPackManifest(
             name: def.name,
             icon: manifestIcon,
             compatibility: def.compatibility,
-            entrypoint: def.entrypoint,
+            entrypoint: entrypoint,
             features: def.features,
             widgets: def.widgets
         )
@@ -4669,7 +4734,6 @@ public final class Engine {
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         let manifestData = try encoder.encode(manifest)
 
-        let defFiles = customInstruments.files(forDefID: def.id)
         let bundleFiles = defFiles.map { HookPackBundle.File(path: $0.path, content: Data($0.content.utf8)) }
 
         return HookPackBundle(

--- a/Sources/LumaCore/Models/CustomInstrumentDef.swift
+++ b/Sources/LumaCore/Models/CustomInstrumentDef.swift
@@ -179,8 +179,9 @@ public struct CustomInstrumentDef: Codable, Identifiable, Sendable, Equatable, F
     private static func parseFeature(_ obj: [String: Any]) -> Feature? {
         guard let id = obj["id"] as? String, let name = obj["name"] as? String else { return nil }
         let schema = parseFeatureSchema(obj["schema"]) ?? .boolean(default: false)
+        let optional = (obj["optional"] as? Bool) ?? true
         let enabledByDefault = (obj["enabled_by_default"] as? Bool) ?? true
-        return Feature(id: id, name: name, schema: schema, enabledByDefault: enabledByDefault)
+        return Feature(id: id, name: name, schema: schema, optional: optional, enabledByDefault: enabledByDefault)
     }
 
     private static func parseFeatureSchema(_ raw: Any?) -> FeatureSchema? {
@@ -198,6 +199,7 @@ public struct CustomInstrumentDef: Codable, Identifiable, Sendable, Equatable, F
         var out: [String: Any] = [
             "id": feature.id,
             "name": feature.name,
+            "optional": feature.optional,
             "enabled_by_default": feature.enabledByDefault,
         ]
         if let data = try? JSONEncoder().encode(feature.schema),

--- a/Sources/LumaCore/Models/CustomInstrumentFile.swift
+++ b/Sources/LumaCore/Models/CustomInstrumentFile.swift
@@ -34,7 +34,8 @@ public struct CustomInstrumentFile: Sendable, Equatable, FetchableRecord, Persis
         guard let path = obj["path"] as? String,
             let content = obj["content"] as? String
         else { return nil }
-        return CustomInstrumentFile(defID: defID, path: path, content: content)
+        guard let validatedPath = try? validateRelativePath(path) else { return nil }
+        return CustomInstrumentFile(defID: defID, path: validatedPath, content: content)
     }
 
     public static func sortedByPath(_ files: [CustomInstrumentFile], entrypoint: String) -> [CustomInstrumentFile] {
@@ -48,6 +49,32 @@ public struct CustomInstrumentFile: Sendable, Equatable, FetchableRecord, Persis
     public static func workspaceRelativePath(defID: UUID, path: String) -> String {
         let encoded = path.replacingOccurrences(of: " ", with: "%20")
         return "InstrumentSources/Custom/\(defID.uuidString)/\(encoded)"
+    }
+
+    public static func validateRelativePath(_ rawPath: String) throws -> String {
+        let path = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !path.isEmpty else {
+            throw LumaCoreError.invalidArgument("File path must not be empty.")
+        }
+        guard path.utf8.count <= 512 else {
+            throw LumaCoreError.invalidArgument("File path is too long.")
+        }
+        guard !path.hasPrefix("/"), !path.hasPrefix("\\") else {
+            throw LumaCoreError.invalidArgument("File path must be relative.")
+        }
+        guard !path.contains("\\") else {
+            throw LumaCoreError.invalidArgument("File path must use '/' separators.")
+        }
+        guard path.rangeOfCharacter(from: .controlCharacters) == nil else {
+            throw LumaCoreError.invalidArgument("File path contains a control character.")
+        }
+
+        let components = path.split(separator: "/", omittingEmptySubsequences: false)
+        guard components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+            throw LumaCoreError.invalidArgument("File path must not contain '.', '..', or empty path segments.")
+        }
+
+        return path
     }
 }
 

--- a/Sources/LumaCore/Persistence/ProjectStore.swift
+++ b/Sources/LumaCore/Persistence/ProjectStore.swift
@@ -946,6 +946,36 @@ public final class ProjectStore: Sendable {
         }
     }
 
+    public func countMissionActions(missionID: UUID) throws -> Int {
+        try db.read { db in
+            try Int.fetchOne(
+                db,
+                sql: "SELECT COUNT(*) FROM mission_action WHERE mission_id = ?",
+                arguments: [missionID.uuidString]
+            ) ?? 0
+        }
+    }
+
+    public func hasPendingMissionActions(missionID: UUID) throws -> Bool {
+        try db.read { db in
+            let count = try Int.fetchOne(
+                db,
+                sql: "SELECT 1 FROM mission_action WHERE mission_id = ? AND status = ? LIMIT 1",
+                arguments: [missionID.uuidString, MissionActionStatus.pending.rawValue]
+            )
+            return count != nil
+        }
+    }
+
+    public func fetchPendingMissionActions(missionID: UUID) throws -> [MissionAction] {
+        try db.read { db in
+            try MissionAction
+                .filter(Column("mission_id") == missionID && Column("status") == MissionActionStatus.pending.rawValue)
+                .order(Column("requested_at").asc)
+                .fetchAll(db)
+        }
+    }
+
     public func fetchMissionAction(id: UUID) throws -> MissionAction? {
         try db.read { db in
             try MissionAction.fetchOne(db, key: id)


### PR DESCRIPTION
## Summary

This fixes several bug-prone paths found during a broad review:

- generate embedded agent bundles from SwiftPM builds without relying on checked-in generated sources
- validate custom instrument file paths and entrypoints before writing, exporting, compiling, or accepting collaboration updates
- surface custom instrument edit failures in UI and mission tools instead of silently dropping them
- guard MCP HTTP parsing, compiler diagnostics, SSE response casts, Metal render setup, and itrace drain negotiation against malformed input or unavailable runtime resources

## Root cause

Several paths trusted generated files, user-controlled instrument paths, collaboration payloads, compiler payloads, or local Metal/runtime availability. In bad states these could either write outside the intended source tree, silently fail, hang agent execution, or crash via force unwraps / force casts.

## Validation

- `env -u SDKROOT swift build --target LumaCore`
- `git diff --check`
- `xcodebuild -project Luma.xcodeproj -scheme Luma -configuration Release -derivedDataPath /Users/sunwoo/work/luma/build/.derived CONFIGURATION_BUILD_DIR=/Users/sunwoo/work/luma/build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO EXCLUDED_SOURCE_FILE_NAMES='*.metal' build`

The Xcode validation intentionally disables signing and excludes `.metal` sources because this local environment is missing the signing setup and Metal Toolchain needed for the full `make` path.
