### PR TITLE
Fix mission session providers

### DIFF
--- a/Luma/Mission/MissionView.swift
+++ b/Luma/Mission/MissionView.swift
@@ -116,7 +116,7 @@ struct MissionView: View {
             case .textDelta(let text):
                 pendingLiveText.append(text)
                 scheduleLiveFlush()
-            case .messageStop, .finalMessage:
+            case .liveTextCleared:
                 pendingLiveText = ""
                 liveFlushTask?.cancel()
                 liveFlushTask = nil

--- a/Luma/Mission/NewMissionSheet.swift
+++ b/Luma/Mission/NewMissionSheet.swift
@@ -166,11 +166,11 @@ struct NewMissionSheet: View {
                         }
                     }
 
-                    if currentProviderRequiresKey {
+                    if currentProviderSupportsKey {
                         if checkingAPIKey {
                             HStack { ProgressView().scaleEffect(0.7); Text("Checking saved API key…").foregroundStyle(.secondary) }
                         } else if !hasStoredAPIKey {
-                            SecureField("API key for \(currentProviderDisplayName)", text: $apiKey)
+                            SecureField(apiKeyPrompt, text: $apiKey)
                                 .textFieldStyle(.roundedBorder)
                             Text("Stored under the app's data directory. Never written to the project document.")
                                 .font(.caption)
@@ -231,6 +231,20 @@ struct NewMissionSheet: View {
             .descriptor.capabilities.supports(.apiKey) ?? false
     }
 
+    private var currentProviderSupportsKey: Bool {
+        guard let capabilities = engine.llmRegistry.provider(id: selectedProviderID)?.descriptor.capabilities else {
+            return false
+        }
+        return capabilities.supports(.apiKey) || capabilities.supports(.optionalAPIKey)
+    }
+
+    private var apiKeyPrompt: String {
+        if currentProviderRequiresKey {
+            return "API key for \(currentProviderDisplayName)"
+        }
+        return "API key for \(currentProviderDisplayName) (optional)"
+    }
+
     private var currentProviderSupportsThinking: Bool {
         engine.llmRegistry.provider(id: selectedProviderID)?
             .descriptor.capabilities.supports(.thinking) ?? false
@@ -258,7 +272,7 @@ struct NewMissionSheet: View {
     }
 
     private func refreshAPIKeyStatus() async {
-        guard currentProviderRequiresKey else {
+        guard currentProviderSupportsKey else {
             hasStoredAPIKey = false
             checkingAPIKey = false
             return

--- a/LumaGtk/Sources/LumaGtk/MissionDetailPane.swift
+++ b/LumaGtk/Sources/LumaGtk/MissionDetailPane.swift
@@ -135,7 +135,7 @@ final class MissionDetailPane {
             case .textDelta(let text):
                 self.liveText += text
                 self.transcript.setLiveText(self.liveText)
-            case .messageStop, .finalMessage:
+            case .liveTextCleared:
                 self.liveText = ""
                 self.transcript.setLiveText("")
             default:

--- a/Sources/LumaCore/Agentic/LLMTypes.swift
+++ b/Sources/LumaCore/Agentic/LLMTypes.swift
@@ -218,6 +218,7 @@ public enum LLMTurnEvent: Sendable {
     case usage(LLMUsage)
     case messageStop(LLMStopReason)
     case finalMessage(role: LLMRole, blocks: [LLMContentBlock])
+    case liveTextCleared
 }
 
 public enum LLMProviderError: LocalizedError, Sendable {

--- a/Sources/LumaCore/Agentic/MissionExecutor.swift
+++ b/Sources/LumaCore/Agentic/MissionExecutor.swift
@@ -47,6 +47,7 @@ public final class MissionExecutor {
         if var mission = try? store.fetchMission(id: missionID), mission.status.isLive {
             mission.status = .cancelled
             persistMission(mission)
+            liveDeltaSink?(missionID, .liveTextCleared)
         }
     }
 
@@ -122,6 +123,7 @@ public final class MissionExecutor {
             if !outcome.blocks.isEmpty {
                 do {
                     try persistAssistantTurn(mission: &mission, outcome: outcome)
+                    liveDeltaSink?(mission.id, .liveTextCleared)
                 } catch {
                     failMission(&mission, reason: "Could not persist turn: \(error.localizedDescription)")
                     return
@@ -503,6 +505,7 @@ public final class MissionExecutor {
             try? store.save(turn)
             collaboration?.enqueueMissionTurn(turn)
         }
+        liveDeltaSink?(mission.id, .liveTextCleared)
     }
 }
 

--- a/Sources/LumaCore/Agentic/OpenAICompatibleProvider.swift
+++ b/Sources/LumaCore/Agentic/OpenAICompatibleProvider.swift
@@ -3,18 +3,15 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public struct LocalOpenAICompatibleProvider: LLMProvider {
-    public static let providerID = "local"
-    public static let defaultBaseURL = URL(string: "http://localhost:11434")!
-
+public struct OpenAICompatibleProvider: LLMProvider {
     public let descriptor: LLMProviderDescriptor
     private let session: URLSession
 
-    public init(session: URLSession = .shared, baseURL: URL = LocalOpenAICompatibleProvider.defaultBaseURL) {
+    public init(id: String, displayName: String, baseURL: URL, session: URLSession = .shared) {
         self.session = session
         self.descriptor = LLMProviderDescriptor(
-            id: Self.providerID,
-            displayName: "Local (OpenAI-compatible)",
+            id: id,
+            displayName: displayName,
             capabilities: LLMProviderCapabilities(
                 supported: [.streaming, .toolUse, .customBaseURL, .optionalAPIKey]
             ),
@@ -43,6 +40,28 @@ public struct LocalOpenAICompatibleProvider: LLMProvider {
             baseURL: baseURL ?? descriptor.defaultBaseURL,
             session: session,
             requiresAPIKey: descriptor.capabilities.supports(.apiKey)
+        )
+    }
+}
+
+extension OpenAICompatibleProvider {
+    private static let ollamaBaseURL = URL(string: "http://localhost:11434")!
+
+    public static func local(session: URLSession = .shared) -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(
+            id: "local",
+            displayName: "Local (OpenAI-compatible)",
+            baseURL: ollamaBaseURL,
+            session: session
+        )
+    }
+
+    public static func remote(session: URLSession = .shared) -> OpenAICompatibleProvider {
+        OpenAICompatibleProvider(
+            id: "openai-compatible",
+            displayName: "OpenAI-compatible URL",
+            baseURL: ollamaBaseURL,
+            session: session
         )
     }
 }

--- a/Sources/LumaCore/Agentic/OpenAIProvider.swift
+++ b/Sources/LumaCore/Agentic/OpenAIProvider.swift
@@ -67,8 +67,7 @@ func fetchOpenAICompatibleModels(
     baseURL: URL,
     apiKey: String?
 ) async throws -> [LLMModelInfo] {
-    var url = baseURL
-    url.append(path: "/v1/models")
+    let url = openAICompatibleURL(baseURL: baseURL, path: "/v1/models")
 
     var request = URLRequest(url: url)
     request.setValue("application/json", forHTTPHeaderField: "accept")
@@ -143,12 +142,7 @@ private func driveOpenAIStream(
         }
     }
 
-    var url = baseURL
-    if !url.path.contains("/v1") {
-        url.append(path: "/v1/chat/completions")
-    } else {
-        url.append(path: "/chat/completions")
-    }
+    let url = openAICompatibleURL(baseURL: baseURL, path: "/v1/chat/completions")
 
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
@@ -193,6 +187,18 @@ private func driveOpenAIStream(
         continuation.yield(.finalMessage(role: .assistant, blocks: blocks))
     }
     continuation.yield(.messageStop(accumulator.stopReason ?? .endTurn))
+}
+
+private func openAICompatibleURL(baseURL: URL, path: String) -> URL {
+    var url = baseURL
+    let normalizedPath = path.hasPrefix("/") ? String(path.dropFirst()) : path
+    let components = url.path.split(separator: "/").map(String.init)
+    if components.contains("v1"), normalizedPath.hasPrefix("v1/") {
+        url.append(path: String(normalizedPath.dropFirst(3)))
+    } else {
+        url.append(path: normalizedPath)
+    }
+    return url
 }
 
 private func buildOpenAIRequestBody(_ request: LLMTurnRequest) -> [String: Any] {

--- a/Sources/LumaCore/Engine.swift
+++ b/Sources/LumaCore/Engine.swift
@@ -241,7 +241,8 @@ public final class Engine {
         #endif
         llmRegistry.register(AnthropicProvider())
         llmRegistry.register(OpenAIProvider())
-        llmRegistry.register(LocalOpenAICompatibleProvider())
+        llmRegistry.register(OpenAICompatibleProvider.local())
+        llmRegistry.register(OpenAICompatibleProvider.remote())
         MissionTools.registerStandard(in: missionTools, engine: self)
         missionsObservation = store.observeMissions { [weak self] missions in
             Task { @MainActor in

--- a/Sources/LumaCore/Engine.swift
+++ b/Sources/LumaCore/Engine.swift
@@ -5572,7 +5572,7 @@ public func deleteCustomInstrument(_ defID: UUID) async {
         switch event {
         case .textDelta(let text):
             missionLiveTextByID[missionID, default: ""] += text
-        case .messageStop, .finalMessage:
+        case .liveTextCleared:
             missionLiveTextByID.removeValue(forKey: missionID)
         default:
             break


### PR DESCRIPTION
## Summary
- keep live mission assistant text until the persisted assistant turn is available
- add an OpenAI-compatible URL mission provider alongside the local provider
- allow optional API keys for compatible providers in the macOS mission sheet and avoid duplicate /v1 URL paths

## Verification
- env -u SDKROOT swift build --target LumaCore
- xcodebuild -project Luma.xcodeproj -scheme Luma -configuration Release -derivedDataPath /Users/sunwoo/work/luma/build/.derived CONFIGURATION_BUILD_DIR=/Users/sunwoo/work/luma/build CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO EXCLUDED_SOURCE_FILE_NAMES='*.metal' build