### PR TITLE
Add filtering for Exports/Imports/Symbols

### DIFF
--- a/Luma/ModuleDetailView.swift
+++ b/Luma/ModuleDetailView.swift
@@ -12,6 +12,7 @@ struct ModuleDetailView: View {
     @State private var tab: Tab = .exports
     @State private var selectedRowID: String?
     @State private var facts: [UInt64: AddressFacts] = [:]
+    @State private var filterText: String = ""
 
     enum Tab: String, CaseIterable, Identifiable {
         case exports = "Exports"
@@ -27,19 +28,25 @@ struct ModuleDetailView: View {
     private var loadError: String? { loadErrors[module.id] }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Picker("", selection: $tab) {
-                ForEach(Tab.allCases) { t in
-                    Text(label(for: t)).tag(t)
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 8) {
+                Picker("", selection: $tab) {
+                    ForEach(Tab.allCases) { t in
+                        Text(label(for: t)).tag(t)
+                    }
                 }
-            }
-            .pickerStyle(.segmented)
-            .labelsHidden()
+                .pickerStyle(.segmented)
+                .labelsHidden()
 
-            content
+                content
+            }
+            .padding(.leading, 12)
+            .padding(.top, 8)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            Divider()
+            filterBar
         }
-        .padding(.leading, 12)
-        .padding(.top, 8)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .task(id: module.id) {
             guard bundles[module.id] == nil, loadError == nil else { return }
@@ -55,9 +62,9 @@ struct ModuleDetailView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
             switch tab {
-            case .exports: exportsTable(displayBundle.exports)
-            case .imports: importsTable(displayBundle.imports)
-            case .symbols: symbolsTable(displayBundle.symbols)
+            case .exports: exportsTable(filteredExports)
+            case .imports: importsTable(filteredImports)
+            case .symbols: symbolsTable(filteredSymbols)
             }
         }
     }
@@ -69,6 +76,74 @@ struct ModuleDetailView: View {
         case .imports: return "Imports (\(bundle.imports.count))"
         case .symbols: return "Symbols (\(bundle.symbols.count))"
         }
+    }
+
+    private var filteredExports: [LumaCore.ModuleSymbolBundle.Export] {
+        let rows = displayBundle.exports
+        guard !filterText.isEmpty else { return rows }
+        let q = filterText.lowercased()
+        return rows.filter {
+            $0.name.lowercased().contains(q) ||
+            $0.kind.rawValue.lowercased().contains(q) ||
+            String(format: "0x%llx", $0.address).contains(q)
+        }
+    }
+
+    private var filteredImports: [LumaCore.ModuleSymbolBundle.Import] {
+        let rows = displayBundle.imports
+        guard !filterText.isEmpty else { return rows }
+        let q = filterText.lowercased()
+        return rows.filter {
+            $0.name.lowercased().contains(q) ||
+            ($0.module?.lowercased().contains(q) ?? false) ||
+            ($0.kind?.rawValue.lowercased().contains(q) ?? false) ||
+            ($0.address.map { String(format: "0x%llx", $0).contains(q) } ?? false)
+        }
+    }
+
+    private var filteredSymbols: [LumaCore.ModuleSymbolBundle.Symbol] {
+        let rows = displayBundle.symbols
+        guard !filterText.isEmpty else { return rows }
+        let q = filterText.lowercased()
+        return rows.filter {
+            $0.name.lowercased().contains(q) ||
+            $0.type.lowercased().contains(q) ||
+            ($0.sectionID?.lowercased().contains(q) ?? false) ||
+            ($0.size.map { String(format: "0x%x", $0).contains(q) } ?? false) ||
+            String(format: "0x%llx", $0.address).contains(q)
+        }
+    }
+
+    private var filterCounts: (shown: Int, total: Int) {
+        switch tab {
+        case .exports: return (filteredExports.count, displayBundle.exports.count)
+        case .imports: return (filteredImports.count, displayBundle.imports.count)
+        case .symbols: return (filteredSymbols.count, displayBundle.symbols.count)
+        }
+    }
+
+    private var filterBar: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .foregroundStyle(.secondary)
+                .font(.system(size: 11))
+            TextField("Filter", text: $filterText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+            if !filterText.isEmpty {
+                let counts = filterCounts
+                Text("Showing \(counts.shown) of \(counts.total)")
+                    .foregroundStyle(.secondary)
+                    .font(.system(size: 11))
+                Button(action: { filterText = "" }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 5)
     }
 
     private func exportsTable(_ rows: [LumaCore.ModuleSymbolBundle.Export]) -> some View {

--- a/LumaGtk/Sources/LumaGtk/ModuleSymbolsPane.swift
+++ b/LumaGtk/Sources/LumaGtk/ModuleSymbolsPane.swift
@@ -19,10 +19,13 @@ final class ModuleSymbolsPane {
     private let symbolsButton: ToggleButton
     private let listContainer: Box
     private let statusLabel: Label
+    private let filterEntry: SearchEntry
+    private let countLabel: Label
 
     private var bundle: LumaCore.ModuleSymbolBundle?
     private var loadTask: Task<Void, Never>?
     private var tab: Tab = .exports
+    private var filterText: String = ""
 
     enum Tab {
         case exports
@@ -35,11 +38,9 @@ final class ModuleSymbolsPane {
         self.sessionID = sessionID
         self.module = module
 
-        widget = Box(orientation: .vertical, spacing: 8)
+        widget = Box(orientation: .vertical, spacing: 0)
         widget.hexpand = true
         widget.vexpand = true
-        widget.marginStart = 12
-        widget.marginBottom = 8
 
         exportsButton = ToggleButton()
         exportsButton.label = "Exports"
@@ -67,9 +68,34 @@ final class ModuleSymbolsPane {
         listContainer.hexpand = true
         listContainer.vexpand = true
 
-        widget.append(child: toggleBar)
-        widget.append(child: statusLabel)
-        widget.append(child: listContainer)
+        let contentBox = Box(orientation: .vertical, spacing: 8)
+        contentBox.hexpand = true
+        contentBox.vexpand = true
+        contentBox.marginStart = 12
+        contentBox.marginTop = 8
+        contentBox.append(child: toggleBar)
+        contentBox.append(child: statusLabel)
+        contentBox.append(child: listContainer)
+
+        filterEntry = SearchEntry()
+        filterEntry.placeholderText = "Filter"
+        filterEntry.hexpand = true
+
+        countLabel = Label(str: "")
+        countLabel.add(cssClass: "dim-label")
+        countLabel.add(cssClass: "caption")
+
+        let filterBar = Box(orientation: .horizontal, spacing: 6)
+        filterBar.marginStart = 10
+        filterBar.marginEnd = 10
+        filterBar.marginTop = 5
+        filterBar.marginBottom = 5
+        filterBar.append(child: filterEntry)
+        filterBar.append(child: countLabel)
+
+        widget.append(child: contentBox)
+        widget.append(child: Separator(orientation: .horizontal))
+        widget.append(child: filterBar)
 
         exportsButton.onToggled { [weak self] _ in
             MainActor.assumeIsolated {
@@ -89,6 +115,14 @@ final class ModuleSymbolsPane {
             MainActor.assumeIsolated {
                 guard let self, self.symbolsButton.active else { return }
                 self.tab = .symbols
+                self.renderCurrent()
+            }
+        }
+
+        filterEntry.onSearchChanged { [weak self] entry in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.filterText = entry.text
                 self.renderCurrent()
             }
         }
@@ -148,7 +182,8 @@ final class ModuleSymbolsPane {
 
         switch tab {
         case .exports:
-            for export in bundle.exports {
+            let rows = filtered(bundle.exports) { [$0.name, $0.kind.rawValue, hex($0.address)] }
+            for export in rows {
                 list.append(child: makeRow(
                     title: export.name,
                     typeLabel: export.kind.rawValue,
@@ -156,8 +191,10 @@ final class ModuleSymbolsPane {
                     context: exportContext(export)
                 ))
             }
+            setFilterCount(shown: rows.count, total: bundle.exports.count)
         case .imports:
-            for imp in bundle.imports {
+            let rows = filtered(bundle.imports) { [$0.name, $0.module, $0.kind?.rawValue, $0.address.map(hex)] }
+            for imp in rows {
                 let typeLabel = [imp.kind?.rawValue, imp.module].compactMap { $0 }.joined(separator: " · ")
                 let target = importTarget(imp)
                 list.append(child: makeRow(
@@ -167,8 +204,10 @@ final class ModuleSymbolsPane {
                     context: target.context
                 ))
             }
+            setFilterCount(shown: rows.count, total: bundle.imports.count)
         case .symbols:
-            for sym in bundle.symbols {
+            let rows = filtered(bundle.symbols) { [$0.name, $0.type, $0.sectionID, $0.size.map { String(format: "0x%x", $0) }, hex($0.address)] }
+            for sym in rows {
                 let typeLabel = [sym.type, sym.sectionID].compactMap { $0 }.joined(separator: " · ")
                 list.append(child: makeRow(
                     title: sym.name,
@@ -177,9 +216,26 @@ final class ModuleSymbolsPane {
                     context: symbolContext(sym)
                 ))
             }
+            setFilterCount(shown: rows.count, total: bundle.symbols.count)
         }
 
         listContainer.append(child: scroll)
+    }
+
+    private func filtered<T>(_ rows: [T], keys: (T) -> [String?]) -> [T] {
+        guard !filterText.isEmpty else { return rows }
+        let needle = filterText.lowercased()
+        return rows.filter { row in
+            keys(row).contains { $0?.lowercased().contains(needle) ?? false }
+        }
+    }
+
+    private func setFilterCount(shown: Int, total: Int) {
+        countLabel.setText(str: filterText.isEmpty ? "" : "Showing \(shown) of \(total)")
+    }
+
+    private func hex(_ address: UInt64) -> String {
+        String(format: "0x%llx", address)
     }
 
     private func makeRow(title: String, typeLabel: String, address: UInt64?, context: AddressContext) -> ListBoxRow {


### PR DESCRIPTION
The current view only shows a long list but doesn't allow any searching. This adds a filter field at the bottom:

<img width="1100" height="680" alt="image" src="https://github.com/user-attachments/assets/926fb497-a769-42c8-991f-984b20b2a3b4" />
