### PR TITLE
gtk: Stabilize module browse and sidebar reconcile

### DIFF
--- a/LumaGtk/Sources/LumaGtk/MainWindow.swift
+++ b/LumaGtk/Sources/LumaGtk/MainWindow.swift
@@ -39,6 +39,8 @@ final class MainWindow: InstrumentUIHost {
     private var missionsExpansionButton: Button!
     private var missionsExpanded: Bool = true
     private var isReconcilingSidebar: Bool = false
+    private var pendingSidebarGroupReconciles: [String: Bool] = [:]
+    private var sidebarGroupReconcileTask: Task<Void, Never>?
     private var missions: [Mission] = []
     private var missionRowIDs: [UUID] = []
     private var missionSidebarRows: [UUID: ListBoxRow] = [:]
@@ -2375,10 +2377,45 @@ final class MainWindow: InstrumentUIHost {
     private func reconcileSidebarGroupAfterSelection(sessionID: UUID, group: SessionSidebarGroup) {
         // Rebuild the rows after the row signal finishes emitting; mutating the
         // list mid-emission faults inside GTK.
-        Task { @MainActor [weak self] in
+        scheduleGroupChildrenReconcile(sessionID: sessionID, group: group, force: true, reselect: true)
+    }
+
+    private func scheduleGroupChildrenReconcile(
+        sessionID: UUID,
+        group: SessionSidebarGroup,
+        force: Bool = false,
+        reselect: Bool = false
+    ) {
+        let key = groupKey(sessionID: sessionID, group: group)
+        pendingSidebarGroupReconciles[key] = (pendingSidebarGroupReconciles[key] ?? false) || force
+        if reselect {
+            pendingSidebarGroupReconciles["reselect"] = true
+        }
+        guard sidebarGroupReconcileTask == nil else { return }
+        sidebarGroupReconcileTask = Task { @MainActor [weak self] in
+            await Task.yield()
             guard let self else { return }
-            self.reconcileGroupChildren(sessionID: sessionID, group: group)
-            self.selectCurrentSessionsRow()
+            self.sidebarGroupReconcileTask = nil
+            let pending = self.pendingSidebarGroupReconciles
+            self.pendingSidebarGroupReconciles.removeAll()
+            let shouldReselect = pending["reselect"] == true
+            for (key, force) in pending where key != "reselect" {
+                guard let slash = key.lastIndex(of: "/") else { continue }
+                let sessionPart = String(key[..<slash])
+                let groupPart = String(key[key.index(after: slash)...])
+                guard let sessionID = UUID(uuidString: sessionPart) else { continue }
+                let group: SessionSidebarGroup? = switch groupPart {
+                case "modules": .modules
+                case "threads": .threads
+                default: nil
+                }
+                if let group {
+                    self.reconcileGroupChildren(sessionID: sessionID, group: group, force: force)
+                }
+            }
+            if shouldReselect {
+                self.selectCurrentSessionsRow()
+            }
         }
     }
 
@@ -2417,8 +2454,8 @@ final class MainWindow: InstrumentUIHost {
             currentInstrumentDetail?.applySessionState()
             currentInsightDetail?.applySessionState()
             sessionDetailViews[session.id]?.applySessionState()
-            reconcileGroupChildren(sessionID: session.id, group: .modules)
-            reconcileGroupChildren(sessionID: session.id, group: .threads)
+            scheduleGroupChildrenReconcile(sessionID: session.id, group: .modules)
+            scheduleGroupChildrenReconcile(sessionID: session.id, group: .threads)
             updateResumeButtonVisibility()
         case .sessionRemoved(let id):
             removeSessionRows(id)
@@ -2878,7 +2915,20 @@ final class MainWindow: InstrumentUIHost {
         return row
     }
 
-    private func reconcileGroupChildren(sessionID: UUID, group: SessionSidebarGroup) {
+    private func reconcileGroupChildren(sessionID: UUID, group: SessionSidebarGroup, force: Bool = false) {
+        let children = makeGroupChildren(sessionID: sessionID, group: group)
+        let desiredKeys = children.map(\.key)
+        let existingKeys = sessionsRowKinds.compactMap { groupChildKey($0, sessionID: sessionID, group: group) }
+        groupCountLabels[groupKey(sessionID: sessionID, group: group)]?.label =
+            groupCountText(sessionID: sessionID, group: group)
+        if !force, desiredKeys == existingKeys {
+            for child in children {
+                groupChildActions[groupChildActionKey(sessionID: sessionID, group: group, key: child.key)] =
+                    child.onActivate
+            }
+            return
+        }
+
         let outerGuard = isReconcilingSidebar
         isReconcilingSidebar = true
         defer {
@@ -2889,12 +2939,10 @@ final class MainWindow: InstrumentUIHost {
         }
 
         removeGroupChildRows(sessionID: sessionID, group: group)
-        groupCountLabels[groupKey(sessionID: sessionID, group: group)]?.label =
-            groupCountText(sessionID: sessionID, group: group)
         guard let headerIndex = groupHeaderIndex(sessionID: sessionID, group: group) else { return }
 
         var insertAt = headerIndex + 1
-        for child in makeGroupChildren(sessionID: sessionID, group: group) {
+        for child in children {
             let kind: SessionsRow = group == .modules
                 ? .moduleChild(sessionID: sessionID, key: child.key)
                 : .threadChild(sessionID: sessionID, key: child.key)
@@ -3123,7 +3171,7 @@ final class MainWindow: InstrumentUIHost {
             Task { @MainActor in
                 guard let self else { return }
                 for session in self.sessions {
-                    self.reconcileGroupChildren(sessionID: session.id, group: .modules)
+                    self.scheduleGroupChildrenReconcile(sessionID: session.id, group: .modules, force: true)
                 }
                 self.observeModuleAnalysis()
             }

--- a/LumaGtk/Sources/LumaGtk/ModuleSymbolsPane.swift
+++ b/LumaGtk/Sources/LumaGtk/ModuleSymbolsPane.swift
@@ -340,7 +340,10 @@ final class ModuleSymbolsPane {
         guard let page else { return }
         rows = rowData(for: page.rows)
 
-        symbolModel.splice(position: 0, nRemovals: symbolModel.nItems)
+        let previousCount = symbolModel.nItems
+        if previousCount > 0 {
+            symbolModel.splice(position: 0, nRemovals: previousCount)
+        }
         for _ in rows.indices {
             symbolModel.append(string: "")
         }

--- a/LumaGtk/Sources/LumaGtk/SidebarBrowserPopover.swift
+++ b/LumaGtk/Sources/LumaGtk/SidebarBrowserPopover.swift
@@ -24,6 +24,10 @@ final class SidebarBrowserPopover<Item> {
     private var listBox: ListBox?
     private var entries: [Entry] = []
     private var query: String = ""
+    private var filterTask: Task<Void, Never>?
+    private var refreshGeneration: UInt = 0
+
+    private static var visibleRowLimit: Int { 250 }
 
     init(
         items: [Item],
@@ -52,6 +56,7 @@ final class SidebarBrowserPopover<Item> {
         // Pop up after the list-row signal that triggered us finishes emitting;
         // grabbing and reparenting mid-emission faults inside GTK.
         Task { @MainActor [weak self] in
+            await Task.yield()
             self?.buildAndPresent(anchoredTo: anchor)
         }
     }
@@ -89,7 +94,7 @@ final class SidebarBrowserPopover<Item> {
         searchEntry.onSearchChanged { [weak self] entry in
             MainActor.assumeIsolated {
                 self?.query = entry.text
-                self?.refreshList()
+                self?.scheduleRefresh()
             }
         }
         searchEntry.onActivate { [weak self] _ in
@@ -132,17 +137,30 @@ final class SidebarBrowserPopover<Item> {
         _ = searchEntry.grabFocus()
     }
 
+    private func scheduleRefresh() {
+        filterTask?.cancel()
+        filterTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 120_000_000)
+            guard let self, !Task.isCancelled else { return }
+            self.refreshList()
+        }
+    }
+
     private func refreshList() {
         guard let listBox else { return }
+        refreshGeneration &+= 1
+        let generation = refreshGeneration
         let matching = filteredItems()
+        let limit = Self.visibleRowLimit
+        let visible = Array(matching.prefix(limit))
+        let truncated = matching.count > limit
 
-        while let child = listBox.firstChild {
-            listBox.remove(child: child)
-        }
+        clearListBox(listBox)
 
         entries = []
         var previousGroup: String?
-        for item in matching {
+        for item in visible {
+            guard generation == refreshGeneration else { return }
             let group = groupName(item)
             if group != previousGroup {
                 entries.append(.sectionHeader(group))
@@ -155,6 +173,21 @@ final class SidebarBrowserPopover<Item> {
 
         if matching.isEmpty {
             listBox.append(child: makeEmptyRow())
+        } else if truncated {
+            listBox.append(child: makeTruncationRow(shown: visible.count, total: matching.count))
+        }
+    }
+
+    private func clearListBox(_ listBox: ListBox) {
+        // Snapshot children first; removing while walking firstChild races GTK.
+        var children: [Widget] = []
+        var current = listBox.firstChild
+        while let child = current {
+            children.append(child)
+            current = child.nextSibling
+        }
+        for child in children {
+            listBox.remove(child: child)
         }
     }
 
@@ -209,6 +242,23 @@ final class SidebarBrowserPopover<Item> {
         return row
     }
 
+    private func makeTruncationRow(shown: Int, total: Int) -> ListBoxRow {
+        let row = ListBoxRow()
+        row.selectable = false
+        row.activatable = false
+        let label = Label(str: "Showing \(shown) of \(total). Refine the filter to see more.")
+        label.halign = .start
+        label.marginStart = 12
+        label.marginEnd = 12
+        label.marginTop = 6
+        label.marginBottom = 6
+        label.wrap = true
+        label.add(cssClass: "dim-label")
+        label.add(cssClass: "caption")
+        row.set(child: label)
+        return row
+    }
+
     private func filteredItems() -> [Item] {
         let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return items }
@@ -235,6 +285,9 @@ final class SidebarBrowserPopover<Item> {
     }
 
     private func cleanup() {
+        filterTask?.cancel()
+        filterTask = nil
+        refreshGeneration &+= 1
         popover?.unparent()
         popover = nil
         listBox = nil


### PR DESCRIPTION
Defer and coalesce module/thread group rebuilds so attach-time session updates no longer mutate the sidebar list re-entrantly. Cap and debounce the Browse-all popover on large Windows module lists, and avoid empty symbol-model splices.

Hopefully Fixes https://github.com/frida/luma/issues/16 in its entirety.

Please review make sure there is no other issues that were created I used Grok with the new coding model that was released 4.5 