### PR TITLE
ci: Keep shader toolchain releases from replacing app releases

### DIFF
--- a/.github/workflows/shader-toolchain.yml
+++ b/.github/workflows/shader-toolchain.yml
@@ -33,3 +33,4 @@ jobs:
         with:
           body_path: artifacts.txt
           files: artifacts/ShaderToolchain.xcframework.zip
+          make_latest: false


### PR DESCRIPTION
## Summary

- keep `shader-toolchain-*` artifact releases out of GitHub’s Latest release slot
- preserve the existing toolchain asset and build-log publication behavior

## Why

The shader toolchain releases are SwiftPM build dependencies, but `action-gh-release` currently uses GitHub’s default latest-release behavior. As a result, `shader-toolchain-2` replaces the latest user-facing Luma app release and appears as the repository’s Latest release.

Setting `make_latest: false` keeps future toolchain artifact releases from displacing semantic app releases. The already-published `shader-toolchain-2` release will still need a one-time Latest correction in the GitHub UI or Releases API.

## Verification

- parsed `.github/workflows/shader-toolchain.yml` successfully as YAML
- ran `git diff --check`
- confirmed `softprops/action-gh-release@v2` supports `make_latest` values `true`, `false`, and `legacy`

## Risk

Low. This only changes GitHub release metadata selection; artifact creation, upload, checksums, and release assets are unchanged.