### PR TITLE
windows REPL input fix

### DIFF
--- a/LumaGtk/Sources/LumaGtk/ConsoleView.swift
+++ b/LumaGtk/Sources/LumaGtk/ConsoleView.swift
@@ -426,6 +426,9 @@ final class ConsoleView {
             gtk_popover_set_pointing_to(popover.popover_ptr, ptr)
         }
         popover.popup()
+        // A popped GtkPopover takes the keyboard grab. On Windows that reads as the
+        // REPL entry losing focus, so hand the caret straight back to the input.
+        _ = inputEntry.grabFocus()
     }
 
     private func caretRectInEntry() -> (x: Double, y: Double, width: Double, height: Double) {

--- a/LumaGtk/Sources/LumaGtk/FocusScope.swift
+++ b/LumaGtk/Sources/LumaGtk/FocusScope.swift
@@ -1,0 +1,19 @@
+import Gtk
+
+extension WidgetProtocol {
+    /// Clears the toplevel window's focus **only** when the focused widget lives
+    /// inside this subtree — i.e. only when this subtree is about to be rebuilt
+    /// or removed.
+    ///
+    /// Clearing focus unconditionally (setting `root.focus = nil`) steals focus
+    /// from unrelated widgets. The REPL input, for example, sits outside the
+    /// sidebar/detached-badge subtrees that get refreshed on every engine state
+    /// update, so a blanket clear makes the entry lose focus mid-typing.
+    func clearFocusIfInside() {
+        guard let root = self.root else { return }
+        guard let focused = root.focus else { return }
+        if focused.widget_ptr == self.widget_ptr || focused.is_(ancestor: self) {
+            root.focus = nil
+        }
+    }
+}

--- a/LumaGtk/Sources/LumaGtk/MainWindow.swift
+++ b/LumaGtk/Sources/LumaGtk/MainWindow.swift
@@ -2744,11 +2744,9 @@ final class MainWindow: InstrumentUIHost {
     }
 
     private func removeSessionRows(_ sessionID: UUID) {
-        if let rootPtr = sessionsList.root?.ptr {
-            Gtk.WindowRef(raw: rootPtr).focus = nil
-        }
         while let idx = sessionsRowKinds.firstIndex(where: { $0.sessionID == sessionID }) {
             if let row = sessionsList.getRowAt(index: idx) {
+                row.clearFocusIfInside()
                 sessionsList.remove(child: row)
             }
             sessionsRowKinds.remove(at: idx)
@@ -3535,9 +3533,7 @@ final class MainWindow: InstrumentUIHost {
 
     private func refreshDetachedIndicator(for session: LumaCore.ProcessSession) {
         guard let host = sessionDetachedHosts[session.id] else { return }
-        if let rootPtr = host.root?.ptr {
-            Gtk.WindowRef(raw: rootPtr).focus = nil
-        }
+        host.clearFocusIfInside()
         while let child = host.firstChild {
             host.remove(child: child)
         }

--- a/LumaGtk/Sources/LumaGtk/NotebookPane.swift
+++ b/LumaGtk/Sources/LumaGtk/NotebookPane.swift
@@ -202,8 +202,10 @@ final class NotebookPane {
 
     private func rebuildEntries() {
         guard let engine else { return }
-        clearWindowFocus()
-        clearChildren(of: entriesBox)
+        while let child = entriesBox.firstChild {
+            child.clearFocusIfInside()
+            entriesBox.remove(child: child)
+        }
         jsValueKeepers.removeAll()
         pharoCells.removeAll()
         entryRows.removeAll()
@@ -675,12 +677,6 @@ final class NotebookPane {
         return buffer.getText(start: start, end: end, includeHiddenChars: true) ?? ""
     }
 
-    private func clearWindowFocus() {
-        guard let rootPtr = widget.root?.ptr else { return }
-        let window = Gtk.WindowRef(raw: rootPtr)
-        window.focus = nil
-    }
-
     private static func makeWalkthroughStep(number: Int, text: String) -> Box {
         let row = Box(orientation: .horizontal, spacing: 10)
         row.setSizeRequest(width: 350, height: -1)
@@ -808,12 +804,6 @@ final class NotebookPane {
 
         outer.append(child: stack)
         return outer
-    }
-
-    private func clearChildren(of container: Box) {
-        while let child = container.firstChild {
-            container.remove(child: child)
-        }
     }
 }
 

--- a/LumaGtk/Sources/LumaGtk/REPLPane.swift
+++ b/LumaGtk/Sources/LumaGtk/REPLPane.swift
@@ -186,10 +186,8 @@ final class REPLPane {
 
         guard bannerDirty else { return }
 
-        if let rootPtr = widget.root?.ptr {
-            WindowRef(raw: rootPtr).focus = nil
-        }
         if let existing = currentBanner {
+            existing.clearFocusIfInside()
             bannerSlot.remove(child: existing)
             currentBanner = nil
         }


### PR DESCRIPTION
Got an issue on my machine (Windows 11, 25H2) where REPL input field could not be used - it'd lose the keyboard focus almost immediately, effectively making typing impossible.
Not an expert in Swift or GTK, but managed to do something there. +++29 ---23, only related files touched.

Tested on the same system - works, no issues, no new bugs created